### PR TITLE
[release-4.6] Add initial machine-os-content for OKD 4.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM quay.io/openshift/origin-machine-config-operator:4.6 as mcd
+FROM quay.io/openshift/origin-artifacts:4.6 as artifacts
+
+FROM quay.io/coreos-assembler/coreos-assembler:latest AS build
+COPY --from=mcd /usr/bin/machine-config-daemon /srv/addons/usr/libexec/machine-config-daemon
+COPY --from=artifacts /srv/repo/*.rpm /tmp/rpms/
+USER 0
+COPY ./entrypoint.sh /usr/bin
+RUN /usr/bin/entrypoint.sh
+
+FROM scratch
+COPY --from=build /srv/ /srv/
+COPY --from=build /extensions/ /extensions/
+COPY manifests/ /manifests/
+LABEL io.openshift.release.operator=true
+ENTRYPOINT ["/noentry"]

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- vrutkovs
+- LorbusChris
+- smarterclayton
+
+reviewers:
+- vrutkovs
+- LorbusChris
+- smarterclayton

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -107,6 +107,14 @@ pushd /tmp/working
   # Fix localtime symlink
   rm -rf etc/localtime
   ln -s ../usr/share/zoneinfo/UTC etc/localtime
+  # disable systemd-resolved.service. Having it enabled breaks machine-api DNS resolution
+  mkdir -p etc/systemd/system/systemd-resolved.service.d
+  echo -e "[Unit]\nConditionPathExists=/enoent" > etc/systemd/system/systemd-resolved.service.d/disabled.conf
+  mkdir -p etc/NetworkManager/conf.d
+  echo -e "[main]\ndns=default" > etc/NetworkManager/conf.d/dns.conf
+  rm -rf usr/etc/tmpfiles.d/dns.conf
+  mkdir -p etc/systemd/system/coreos-migrate-to-systemd-resolved.service.d
+  echo -e "[Unit]\nConditionPathExists=/enoent" > etc/systemd/system/coreos-migrate-to-systemd-resolved.service.d/disabled.conf
   mv etc usr/
 popd
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,118 @@
+#!/bin/sh
+set -exuo pipefail
+
+REPOS=()
+STREAM="next-devel"
+REF="fedora/x86_64/coreos/${STREAM}"
+
+# additional RPMs to install via os-extensions
+EXTENSION_RPMS=(
+  attr
+  glusterfs
+  glusterfs-client-xlators
+  glusterfs-fuse
+  libgfrpc0
+  libgfxdr0
+  libglusterfs0
+  psmisc
+  NetworkManager-ovs
+  openvswitch
+  dpdk
+  gdbm-libs
+  libxcrypt-compat
+  unbound-libs
+  python3-libs
+  libdrm
+  libmspack
+  libpciaccess
+  pciutils
+  pciutils-libs
+  hwdata
+  python3-libs
+  python3-pip
+  python3
+  python-unversioned-command
+  python-pip-wheel
+  python3-setuptools
+  python-setuptools-wheel
+  open-vm-tools
+  xmlsec1
+  xmlsec1-openssl
+  libxslt
+  libtool-ltdl
+)
+CRIO_RPMS=(
+  cri-o
+  cri-tools
+)
+CRIO_VERSION="1.18"
+
+# fetch binaries and configure working env, prow doesn't allow init containers or a second container
+dir=/tmp/ostree
+mkdir -p "${dir}"
+export PATH=$PATH:/tmp/bin
+export HOME=/tmp
+
+# fetch jq binary
+mkdir $HOME/bin
+curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 2>/dev/null >/tmp/bin/jq
+chmod ug+x $HOME/bin/jq
+
+# fetch fcos release info and check whether we've already built this image
+build_url="https://builds.coreos.fedoraproject.org/prod/streams/${STREAM}/builds"
+curl "${build_url}/builds.json" 2>/dev/null >${dir}/builds.json
+build_id="$( <"${dir}/builds.json" jq -r '.builds[0].id' )"
+base_url="${build_url}/${build_id}/x86_64"
+curl "${base_url}/meta.json" 2>/dev/null >${dir}/meta.json
+tar_url="${base_url}/$( <${dir}/meta.json jq -r .images.ostree.path )"
+commit_id="$( <${dir}/meta.json jq -r '."ostree-commit"' )"
+
+# fetch existing machine-os-content
+mkdir /srv/repo
+curl -L "${tar_url}" | tar xf - -C /srv/repo/ --no-same-owner
+
+# use repos from FCOS
+rm -rf /etc/yum.repos.d
+ostree --repo=/srv/repo checkout "${REF}" --subpath /usr/etc/yum.repos.d --user-mode /etc/yum.repos.d
+dnf clean all
+ostree --repo=/srv/repo cat "${REF}" /usr/lib/os-release > /tmp/os-release
+source /tmp/os-release
+
+# prepare a list of repos to download packages from
+REPOLIST="--enablerepo=fedora --enablerepo=updates"
+for i in "${!REPOS[@]}"; do
+  REPOLIST="${REPOLIST} --repofrompath=repo${i},${REPOS[$i]}"
+done
+
+# build extension repo
+mkdir /extensions
+pushd /extensions
+  mkdir okd
+  yumdownloader --archlist=x86_64 --archlist=noarch --disablerepo='*' --destdir=/extensions/okd --releasever=${VERSION_ID} ${REPOLIST} ${EXTENSION_RPMS[*]}
+  createrepo_c --no-database .
+popd
+
+# inject cri-o, hyperkube RPMs and MCD binary in the ostree commit
+mkdir /tmp/working
+pushd /tmp/working
+  # enable crio
+  sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/fedora-updates-testing-modular.repo
+  dnf module enable -y cri-o:${CRIO_VERSION}
+  yumdownloader --archlist=x86_64 --disablerepo='*' --destdir=/tmp/rpms --enablerepo=updates-testing-modular cri-o cri-tools
+
+  for i in $(find /tmp/rpms/ -iname *.rpm); do
+    echo "Extracting $i ..."
+    rpm2cpio $i | cpio -div
+  done
+  # Fix localtime symlink
+  rm -rf etc/localtime
+  ln -s ../usr/share/zoneinfo/UTC etc/localtime
+  mv etc usr/
+popd
+
+# add binaries (MCD) from /srv/addons
+mkdir -p /tmp/working/usr/bin
+cp -rvf /srv/addons/* /tmp/working/
+
+# build new commit
+coreos-assembler dev-overlay --repo /srv/repo --rev "${REF}" --add-tree /tmp/working --output-ref "${REF}"

--- a/manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml
+++ b/manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml
@@ -1,0 +1,15 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-master-okd-extensions
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+  extensions:
+    - glusterfs
+    - glusterfs-fuse
+    - open-vm-tools
+    - NetworkManager-ovs

--- a/manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml
+++ b/manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml
@@ -1,0 +1,15 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-worker-okd-extensions
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+  extensions:
+    - glusterfs
+    - glusterfs-fuse
+    - open-vm-tools
+    - NetworkManager-ovs


### PR DESCRIPTION
This ports the build part from OKD release periodics into a separate repo.

Currently FCOS default resolver - `systemd-resolved` needs to be disabled as it seems to break CoreDNS resolution