### PR TITLE
Use CRI-O 1.19

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ CRIO_RPMS=(
   cri-o
   cri-tools
 )
-CRIO_VERSION="1.18"
+CRIO_VERSION="1.19"
 
 # fetch binaries and configure working env, prow doesn't allow init containers or a second container
 dir=/tmp/ostree


### PR DESCRIPTION
Use cri-o 1.19 in 4.7 to align with k8s 1.19.

Related: https://github.com/openshift/okd/issues/341

