### PR TITLE
WIP Write "localhost" as an initial hostname

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -115,6 +115,10 @@ pushd /tmp/working
   rm -rf usr/etc/tmpfiles.d/dns.conf
   mkdir -p etc/systemd/system/coreos-migrate-to-systemd-resolved.service.d
   echo -e "[Unit]\nConditionPathExists=/enoent" > etc/systemd/system/coreos-migrate-to-systemd-resolved.service.d/disabled.conf
+  # Workaround for https://github.com/coreos/fedora-coreos-tracker/issues/649
+  mkdir etc/systemd/system-generators
+  echo -e '#!/bin/bash\nprintf "localhost" > /proc/sys/kernel/hostname' > etc/systemd/system-generators/hostname-generator
+  chmod a+x etc/systemd/system-generators/hostname-generator
   mv etc usr/
 popd
 


### PR DESCRIPTION
This works around Fedora 33 decision to use "fedora" as a fallback hostname until its set. As a result MCO doesn't wait for correct hostname to be set by NM