### PR TITLE
[release-4.6] Fix invalid symlink on second boot

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,6 +71,9 @@ commit_id="$( <${dir}/meta.json jq -r '."ostree-commit"' )"
 mkdir /srv/repo
 curl -L "${tar_url}" | tar xf - -C /srv/repo/ --no-same-owner
 
+# Remove all refs except ${REF} so that bootstrap pivot would not be confused
+ostree --repo=/srv/repo refs | grep -v "${REF}" | xargs -n1 ostree --repo=/srv/repo refs --delete
+
 # use repos from FCOS
 rm -rf /etc/yum.repos.d
 ostree --repo=/srv/repo checkout "${REF}" --subpath /usr/etc/yum.repos.d --user-mode /etc/yum.repos.d

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -104,25 +104,17 @@ pushd /tmp/working
     echo "Extracting $i ..."
     rpm2cpio $i | cpio -div
   done
-  # Fix localtime symlink
-  rm -rf etc/localtime
-  ln -s ../usr/share/zoneinfo/UTC etc/localtime
-  # disable systemd-resolved.service. Having it enabled breaks machine-api DNS resolution
-  mkdir -p etc/systemd/system/systemd-resolved.service.d
-  echo -e "[Unit]\nConditionPathExists=/enoent" > etc/systemd/system/systemd-resolved.service.d/disabled.conf
-  mkdir -p etc/NetworkManager/conf.d
-  echo -e "[main]\ndns=default" > etc/NetworkManager/conf.d/dns.conf
-  rm -rf usr/etc/tmpfiles.d/dns.conf
-  mkdir -p etc/systemd/system/coreos-migrate-to-systemd-resolved.service.d
-  echo -e "[Unit]\nConditionPathExists=/enoent" > etc/systemd/system/coreos-migrate-to-systemd-resolved.service.d/disabled.conf
-  # Workaround for https://github.com/coreos/fedora-coreos-tracker/issues/649
-  cp -rvf /srv/overlay/* .
-  mv etc usr/
-popd
 
-# add binaries (MCD) from /srv/addons
-mkdir -p /tmp/working/usr/bin
-cp -rvf /srv/addons/* /tmp/working/
+  # append additional configuration
+  cp -rvf /srv/overlay/* .
+
+  # move etc configuration to /usr/etc so that it would be merged by rpm-ostree
+  mv etc usr/
+
+  # add binaries (MCD) from /srv/addons
+  mkdir -p usr/bin usr/libexec
+  cp -rvf /srv/addons/* .
+popd
 
 # build new commit
 coreos-assembler dev-overlay --repo /srv/repo --rev "${REF}" --add-tree /tmp/working --output-ref "${REF}"

--- a/overlay/etc/NetworkManager/conf.d/dns.conf
+++ b/overlay/etc/NetworkManager/conf.d/dns.conf
@@ -1,0 +1,2 @@
+[main]
+dns=default

--- a/overlay/etc/systemd/system/coreos-migrate-to-systemd-resolved.service.d/disabled.conf
+++ b/overlay/etc/systemd/system/coreos-migrate-to-systemd-resolved.service.d/disabled.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/enoent

--- a/overlay/etc/systemd/system/systemd-resolved.service.d/disabled.conf
+++ b/overlay/etc/systemd/system/systemd-resolved.service.d/disabled.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/enoent

--- a/overlay/usr/lib/tmpfiles.d/etc.conf
+++ b/overlay/usr/lib/tmpfiles.d/etc.conf
@@ -1,0 +1,12 @@
+ #  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+# See tmpfiles.d(5) for details
+L /etc/os-release - - - - ../usr/lib/os-release
+L+ /etc/mtab - - - - ../proc/self/mounts
+C! /etc/nsswitch.conf - - - -
+C! /etc/pam.d - - - -
+C! /etc/issue - - - -


### PR DESCRIPTION
This PR includes:
* #8 - This replaces `echo -n` way to create files on host
* Remove additional refs (FCOS version tag) which confuses bootstrap (it expects a single ref)
* Avoid creating /etc/resolv.conf symlink to systemd-resolved managed file

Related to https://github.com/openshift/okd/issues/380