### PR TITLE
Layer root/* files on host, fix invalid symlink on second boot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY --from=mcd /usr/bin/machine-config-daemon /srv/addons/usr/libexec/machine-c
 COPY --from=artifacts /srv/repo/*.rpm /tmp/rpms/
 USER 0
 COPY ./entrypoint.sh /usr/bin
+COPY ./overlay /srv/overlay
 RUN /usr/bin/entrypoint.sh
 
 FROM scratch

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,6 +71,9 @@ commit_id="$( <${dir}/meta.json jq -r '."ostree-commit"' )"
 mkdir /srv/repo
 curl -L "${tar_url}" | tar xf - -C /srv/repo/ --no-same-owner
 
+# Remove all refs except ${REF} so that bootstrap pivot would not be confused
+ostree --repo=/srv/repo refs | grep -v "${REF}" | xargs -n1 ostree --repo=/srv/repo refs --delete
+
 # use repos from FCOS
 rm -rf /etc/yum.repos.d
 ostree --repo=/srv/repo checkout "${REF}" --subpath /usr/etc/yum.repos.d --user-mode /etc/yum.repos.d

--- a/overlay/etc/NetworkManager/conf.d/dns.conf
+++ b/overlay/etc/NetworkManager/conf.d/dns.conf
@@ -1,0 +1,2 @@
+[main]
+dns=default

--- a/overlay/etc/systemd/system/coreos-migrate-to-systemd-resolved.service.d/disabled.conf
+++ b/overlay/etc/systemd/system/coreos-migrate-to-systemd-resolved.service.d/disabled.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/enoent

--- a/overlay/etc/systemd/system/systemd-resolved.service.d/disabled.conf
+++ b/overlay/etc/systemd/system/systemd-resolved.service.d/disabled.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/enoent

--- a/overlay/usr/lib/tmpfiles.d/etc.conf
+++ b/overlay/usr/lib/tmpfiles.d/etc.conf
@@ -1,0 +1,12 @@
+ #  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+# See tmpfiles.d(5) for details
+L /etc/os-release - - - - ../usr/lib/os-release
+L+ /etc/mtab - - - - ../proc/self/mounts
+C! /etc/nsswitch.conf - - - -
+C! /etc/pam.d - - - -
+C! /etc/issue - - - -


### PR DESCRIPTION
This PR includes:

* #8 - This replaces echo -n way to create files on host
* Remove additional refs (FCOS version tag) which confuses bootstrap (it expects a single ref)
* Avoid creating /etc/resolv.conf symlink to systemd-resolved managed file

master version of https://github.com/openshift/okd-machine-os/pull/12