### PR TITLE
overlay: add custom /etc/nsswitch.conf

### DIFF
--- a/overlay/etc/nsswitch.conf
+++ b/overlay/etc/nsswitch.conf
@@ -1,0 +1,70 @@
+#
+# /etc/nsswitch.conf
+#
+# Name Service Switch config file. This file should be
+# sorted with the most-used services at the beginning.
+#
+# Valid databases are: aliases, ethers, group, gshadow, hosts,
+# initgroups, netgroup, networks, passwd, protocols, publickey,
+# rpc, services, and shadow.
+#
+# Valid service provider entries include (in alphabetical order):
+#
+#	compat			Use /etc files plus *_compat pseudo-db
+#	db			Use the pre-processed /var/db files
+#	dns			Use DNS (Domain Name Service)
+#	files			Use the local files in /etc
+#	hesiod			Use Hesiod (DNS) for user lookups
+#
+# See `info libc 'NSS Basics'` for more information.
+#
+# Commonly used alternative service providers (may need installation):
+#
+#	ldap			Use LDAP directory server
+#	myhostname		Use systemd host names
+#	mymachines		Use systemd machine names
+#	mdns*, mdns*_minimal	Use Avahi mDNS/DNS-SD
+#	resolve			Use systemd resolved resolver
+#	sss			Use System Security Services Daemon (sssd)
+#	systemd			Use systemd for dynamic user option
+#	winbind			Use Samba winbind support
+#	wins			Use Samba wins support
+#	wrapper			Use wrapper module for testing
+#
+# Notes:
+#
+# 'sssd' performs its own 'files'-based caching, so it should generally
+# come before 'files'.
+#
+# WARNING: Running nscd with a secondary caching service like sssd may
+# 	   lead to unexpected behaviour, especially with how long
+# 	   entries are cached.
+#
+# Installation instructions:
+#
+# To use 'db', install the appropriate package(s) (provide 'makedb' and
+# libnss_db.so.*), and place the 'db' in front of 'files' for entries
+# you want to be looked up first in the databases, like this:
+#
+# passwd:    db files
+# shadow:    db files
+# group:     db files
+
+# In order of likelihood of use to accelerate lookup.
+passwd: sss files altfiles systemd
+shadow:     files
+group: sss files altfiles systemd
+hosts: files dns myhostname
+services:   files sss
+netgroup:   sss
+automount:  files sss
+
+aliases:    files
+ethers:     files
+gshadow:    files
+# Allow initgroups to default to the setting for group.
+# initgroups: files
+networks:   files dns
+protocols:  files
+publickey:  files
+rpc:        files


### PR DESCRIPTION
systemd-resolved seems to break mDNS plugin used in oVirt/vSphere installs.

Instead of
> hosts:      files resolve [!UNAVAIL=return] myhostname dns

we should be using

> hosts: files dns myhostname

(as in F32).

Ref: https://github.com/openshift/okd/issues/401