### PR TITLE
overlay: run gcp-hostname on GCP only

### DIFF
--- a/overlay/etc/systemd/system/gcp-hostname.service
+++ b/overlay/etc/systemd/system/gcp-hostname.service
@@ -1,5 +1,8 @@
 [Unit]
 Description=Set GCP Transient Hostname
+# Run for GCP only
+ConditionKernelCommandLine=|ignition.platform.id=gce
+ConditionKernelCommandLine=|ignition.platform.id=gcp
 # Removal of this file signals firstboot completion
 ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
 # Block services relying on Networking being up.


### PR DESCRIPTION
Currently this service starts on any install types. We should be running it on GCP only to prevent it from failing on AWS/baremetal etc. and confusing users.

Ref: https://github.com/openshift/okd/issues/396