### PR TITLE
Remove resolved overlay config

### DIFF
--- a/overlay/etc/systemd/resolved.conf.d/no-dns-stub.conf
+++ b/overlay/etc/systemd/resolved.conf.d/no-dns-stub.conf
@@ -1,2 +1,0 @@
-[Resolve]
-DNSStubListener=no


### PR DESCRIPTION
DNSStubListener=no makes it so that systemd-resolved reads rather
than manages /etc/resolv.conf. Remove this to make NetworkManager
configure resolved, managing /etc/resolv.conf.