### PR TITLE
bootstrap: add pre-pivot.sh

### DIFF
--- a/bootstrap/pre-pivot.sh
+++ b/bootstrap/pre-pivot.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Load common functions
+. /usr/local/bin/release-image.sh
+
+# Copy pivot files
+cp overlay/etc / -rvf
+cp overlay/usr/local/bin/* /usr/local/bin/ -rvf
+cp manifests/* /opt/openshift/openshift/ -rvf
+
+# Copy machine-config-daemon binary from payload
+MACHINE_CONFIG_OPERATOR_IMAGE=$(image_for machine-config-operator)
+while ! podman pull --quiet "$MACHINE_CONFIG_OPERATOR_IMAGE"
+do
+    echo "Pull failed. Retrying $MACHINE_CONFIG_OPERATOR_IMAGE..."
+done
+mnt=$(podman image mount "${MACHINE_CONFIG_OPERATOR_IMAGE}")
+cp ${mnt}/usr/bin/machine-config-daemon /usr/local/bin/machine-config-daemon
+chmod +x /usr/local/bin/machine-config-daemon
+restorecon /usr/local/bin/machine-config-daemon
+
+# Set image-pullspec for pivot
+mkdir --parents /run/pivot /etc/pivot
+MACHINE_CONFIG_OSCONTENT=$(image_for machine-os-content)
+echo "${MACHINE_CONFIG_OSCONTENT}" > /etc/pivot/image-pullspec
+touch /run/pivot/reboot-needed
+
+touch /opt/openshift/.pivot-done
+/usr/local/bin/machine-config-daemon pivot
+
+systemctl reboot


### PR DESCRIPTION
This script would run during release-image-download.sh and update the bootstrap node:

* Copy pivot files from `bootstrap/` to add necessary bootstrap node modifications
* Extract MCD from the image and place it to /usr/local/bin/machine-config-daemon
* Prepare image-pullspec
* Run `machine-config-daemon pivot` and reboot

Once this lands I'll update installer fork to run this script instead of amending `release-image-download.sh`