### PR TITLE
Add kernel-headers to internal repo

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,7 @@ EXTENSION_RPMS=(
   glusterfs-client-xlators
   glusterfs-fuse
   kernel-devel
+  kernel-headers
   libdrm
   libgfrpc0
   libgfxdr0


### PR DESCRIPTION

This package is being installed during MCO tests, along with kernel-devel. Required to pass TestKernelType test in MCO's okd-gcp-op