### PR TITLE
[4.6] Pin FCOS to 33.20201209.10.0

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,8 +88,9 @@ chmod ug+x $HOME/bin/jq
 
 # fetch fcos release info and check whether we've already built this image
 build_url="https://builds.coreos.fedoraproject.org/prod/streams/${STREAM}/builds"
-curl "${build_url}/builds.json" 2>/dev/null >${dir}/builds.json
-build_id="$( <"${dir}/builds.json" jq -r '.builds[0].id' )"
+# curl "${build_url}/builds.json" 2>/dev/null >${dir}/builds.json
+# build_id="$( <"${dir}/builds.json" jq -r '.builds[0].id' )"
+build_id="33.20201209.10.0"
 base_url="${build_url}/${build_id}/x86_64"
 curl "${base_url}/meta.json" 2>/dev/null >${dir}/meta.json
 tar_url="${base_url}/$( <${dir}/meta.json jq -r .images.ostree.path )"


### PR DESCRIPTION
Latest FCOS breaks the cluster - workers can't join the cluster. Use latest passing build while we investigate.

Cherry-pick of https://github.com/openshift/okd-machine-os/pull/50

https://bugzilla.redhat.com/show_bug.cgi?id=1908527