### PR TITLE
[4.6] Use FCOS stable stream

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -88,9 +88,8 @@ chmod ug+x $HOME/bin/jq
 
 # fetch fcos release info and check whether we've already built this image
 build_url="https://builds.coreos.fedoraproject.org/prod/streams/${STREAM}/builds"
-# curl "${build_url}/builds.json" 2>/dev/null >${dir}/builds.json
-# build_id="$( <"${dir}/builds.json" jq -r '.builds[0].id' )"
-build_id="33.20201209.10.0"
+curl "${build_url}/builds.json" 2>/dev/null >${dir}/builds.json
+build_id="$( <"${dir}/builds.json" jq -r '.builds[0].id' )"
 base_url="${build_url}/${build_id}/x86_64"
 curl "${base_url}/meta.json" 2>/dev/null >${dir}/meta.json
 tar_url="${base_url}/$( <${dir}/meta.json jq -r .images.ostree.path )"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -exuo pipefail
 
 REPOS=()
-STREAM="next-devel"
+STREAM="stable"
 REF="fedora/x86_64/coreos/${STREAM}"
 
 # additional RPMs to install via os-extensions


### PR DESCRIPTION
This reverts commit 2a0fec2c9fc9384e7d51e240475561e8eb9a4a36 and switches FCOS stream to stable.

Fixes https://github.com/openshift/okd/issues/383