### PR TITLE
[4.6] Symlink resolv.conf to /run/systemd/resolve/resolv.conf

### DIFF
--- a/overlay/etc/resolv.conf
+++ b/overlay/etc/resolv.conf
@@ -1,0 +1,1 @@
+../run/systemd/resolve/resolv.conf

--- a/overlay/etc/systemd/resolved.conf.d/no-dns-stub.conf
+++ b/overlay/etc/systemd/resolved.conf.d/no-dns-stub.conf
@@ -1,0 +1,2 @@
+[Resolve]
+DNSStubListener=no


### PR DESCRIPTION
After pivot systemd-resolved cannot reset /etc/resolv.conf symlink due to a SELinux issue (https://github.com/coreos/fedora-coreos-tracker/issues/649). Bring back DNSStubListener setting for systemd-resolved.

Cherry-pick of #52 on release-4.6, fixes https://github.com/openshift/okd/issues/440