### PR TITLE
overlay: symlink /etc/localtime to UTC

### DIFF
--- a/overlay/etc/localtime
+++ b/overlay/etc/localtime
@@ -1,0 +1,1 @@
+../usr/share/zoneinfo/UTC


### PR DESCRIPTION
On boot empty `/etc/localtime` dir is being created, which breaks fluentd.

OKD payload should default to UTC.

Related: https://github.com/openshift/okd/issues/310