### PR TITLE
entrypoint: remove open-vm-tools from extension RPMs

### DIFF
--- a/manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml
+++ b/manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml
@@ -11,6 +11,5 @@ spec:
   extensions:
     - glusterfs
     - glusterfs-fuse
-    - open-vm-tools
     - qemu-guest-agent
     - NetworkManager-ovs

--- a/manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml
+++ b/manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml
@@ -11,6 +11,5 @@ spec:
   extensions:
     - glusterfs
     - glusterfs-fuse
-    - open-vm-tools
     - qemu-guest-agent
     - NetworkManager-ovs


### PR DESCRIPTION
OKD content layers open-vm-tools and dependencies so that bootstrap node would be visible in vSphere installs. Later on we request this RPM to be installed as well.

This makes `rpm-ostree` race as it may unexpectedly find the existing file.