### PR TITLE
overlay: support RSA keys

### DIFF
--- a/bootstrap/overlay/etc/ssh/sshd_config.d/10-insecure-rsa-keysig.conf
+++ b/bootstrap/overlay/etc/ssh/sshd_config.d/10-insecure-rsa-keysig.conf
@@ -1,0 +1,1 @@
+PubkeyAcceptedKeyTypes=+ssh-rsa

--- a/overlay/etc/ssh/sshd_config.d/10-insecure-rsa-keysig.conf
+++ b/overlay/etc/ssh/sshd_config.d/10-insecure-rsa-keysig.conf
@@ -1,0 +1,1 @@
+PubkeyAcceptedKeyTypes=+ssh-rsa


### PR DESCRIPTION
In general this is insecure, but its necessary for OKD CI for now.

Master version of #55