### PR TITLE
overlay: remove resolv.conf symlink

### DIFF
--- a/overlay/etc/resolv.conf
+++ b/overlay/etc/resolv.conf
@@ -1,1 +1,0 @@
-../run/systemd/resolve/resolv.conf


### PR DESCRIPTION
This is no longer necessary, as latest FCOS already does that