### PR TITLE
overlay: link resolv.conf to stub resolv.conf

### DIFF
--- a/overlay/resolv.conf
+++ b/overlay/resolv.conf
@@ -1,0 +1,1 @@
+../run/systemd/resolve/stub-resolv.conf


### PR DESCRIPTION
This file is being created by systemd-resolv on initial boot - and DNS settings from kargs being passed there.

Instead of starting from scratch when OKD payload boots we'll start with preserved DNS settings.