### PR TITLE
overlay: copy stub resolv.conf to /etc/resolv.conf

### DIFF
--- a/overlay/etc/systemd/system/NetworkManager.service.wants/copy-resolv.service
+++ b/overlay/etc/systemd/system/NetworkManager.service.wants/copy-resolv.service
@@ -1,0 +1,1 @@
+../copy-resolv.service

--- a/overlay/etc/systemd/system/copy-resolv.service
+++ b/overlay/etc/systemd/system/copy-resolv.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Copy stub-resolv.conf to resolv.conf
+# Run for vSphere/Openstack only
+ConditionKernelCommandLine=|ignition.platform.id=vmware
+ConditionKernelCommandLine=|ignition.platform.id=openstack
+# Run before NM dispatcher scripts run
+Before=NetworkManager.service
+[Service]
+Type=oneshot
+ExecStart=/bin/cp -rn /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf
+[Install]
+WantedBy=NetworkManager.service


### PR DESCRIPTION
This file is being created by systemd-resolv on initial boot - and DNS settings from kargs being passed there.

Instead of starting from scratch when OKD payload boots we'll start with preserved DNS settings.

Cherry-pick of #66 on release-4.6