### PR TITLE
[release-4.6] bootstrap overlay: add resolv.conf symlink

### DIFF
--- a/bootstrap/pre-pivot.sh
+++ b/bootstrap/pre-pivot.sh
@@ -5,6 +5,8 @@
 
 # Copy pivot files
 cp overlay/etc / -rvf
+rm -rf /etc/resolv.conf
+ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf
 cp overlay/usr/local/bin/* /usr/local/bin/ -rvf
 cp manifests/* /opt/openshift/openshift/ -rvf
 


### PR DESCRIPTION
This reverts commit 85125b12e093abb8452027613ae4ee98f6ece437.

This symlink is necessary on boostrap for vSphere install to pass