### PR TITLE
bootstrap overlay: add resolv.conf symlink

### DIFF
--- a/bootstrap/overlay/etc/resolv.conf
+++ b/bootstrap/overlay/etc/resolv.conf
@@ -1,0 +1,1 @@
+../run/systemd/resolve/resolv.conf


### PR DESCRIPTION
This symlink is necessary for bootstrap to pull OKD content