### PR TITLE
Install CRI-O from OBS

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 set -exuo pipefail
 
-REPOS=()
 STREAM="next-devel"
 REF="fedora/x86_64/coreos/${STREAM}"
 
+# additional repos to use
+REPOS=()
 # additional RPMs to install via os-extensions
 EXTENSION_RPMS=(
   NetworkManager-ovs
@@ -110,10 +111,20 @@ dnf clean all
 ostree --repo=/srv/repo cat "${REF}" /usr/lib/os-release > /tmp/os-release
 source /tmp/os-release
 
+# Some repos are version-dependent
+CRIO_REPOS=(
+  https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/${CRIO_VERSION}/Fedora_${VERSION_ID}/
+)
+# TODO add cri-tools when its built for F33
+# https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Fedora_${VERSION_ID}/
+
 # prepare a list of repos to download packages from
 REPOLIST="--enablerepo=fedora --enablerepo=updates"
 for i in "${!REPOS[@]}"; do
   REPOLIST="${REPOLIST} --repofrompath=repo${i},${REPOS[$i]}"
+done
+for i in "${!CRIO_REPOS[@]}"; do
+  REPOLIST="${REPOLIST} --repofrompath=repo${i},${CRIO_REPOS[$i]}"
 done
 
 # yumdownloader params
@@ -131,8 +142,10 @@ popd
 yumdownloader ${YUMD_PARAMS} --destdir=/tmp/rpms ${BOOTSTRAP_RPMS[*]}
 
 # download CRI-O RPMs
+# TODO: when a new cri-tools build is available remove enabling a module
+yumdownloader ${YUMD_PARAMS} --destdir=/tmp/rpms crio
 dnf module enable -y --enablerepo=updates-testing-modular cri-o:${CRIO_VERSION}
-yumdownloader ${YUMD_PARAMS} --destdir=/tmp/rpms --enablerepo=updates-testing-modular cri-o cri-tools
+yumdownloader ${YUMD_PARAMS} --destdir=/tmp/rpms --enablerepo=updates-testing-modular cri-tools
 
 # inject MCD binary and cri-o, hyperkube, and bootstrap RPMs in the ostree commit
 mkdir /tmp/working


### PR DESCRIPTION
Use published packages built on OBS instead of Fedora's bodhi and 
modularity.
~~This uses older `cri-tools` from Fedora, until its available in OBS.~~

Ref: https://github.com/openshift/okd/issues/463