### PR TITLE
bootstrap: remove open-vm-tools requests

### DIFF
--- a/bootstrap/manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml
+++ b/bootstrap/manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml
@@ -11,6 +11,5 @@ spec:
   extensions:
     - glusterfs
     - glusterfs-fuse
-    - open-vm-tools
     - qemu-guest-agent
     - NetworkManager-ovs

--- a/bootstrap/manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml
+++ b/bootstrap/manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml
@@ -11,6 +11,5 @@ spec:
   extensions:
     - glusterfs
     - glusterfs-fuse
-    - open-vm-tools
     - qemu-guest-agent
     - NetworkManager-ovs


### PR DESCRIPTION
`open-vm-tools` RPM is still requested in bootstrap manifests