### PR TITLE
overlay: start open-vm-tools services

### DIFF
--- a/overlay/etc/systemd/system/multi-user.target.wants/vmtoolsd.service
+++ b/overlay/etc/systemd/system/multi-user.target.wants/vmtoolsd.service
@@ -1,0 +1,1 @@
+../../../../usr/lib/systemd/system/vmtoolsd.service

--- a/overlay/etc/systemd/system/vmtoolsd.service.requires/vgauthd.service
+++ b/overlay/etc/systemd/system/vmtoolsd.service.requires/vgauthd.service
@@ -1,0 +1,1 @@
+../../../../usr/lib/systemd/system/vgauthd.service


### PR DESCRIPTION
vSphere tools services should autorun on masters.

Related: https://github.com/openshift/okd/issues/483