### PR TITLE
WIP 4.6 remove qemu guest agent

### DIFF
--- a/bootstrap/manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml
+++ b/bootstrap/manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml
@@ -11,5 +11,4 @@ spec:
   extensions:
     - glusterfs
     - glusterfs-fuse
-    - qemu-guest-agent
     - NetworkManager-ovs

--- a/bootstrap/manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml
+++ b/bootstrap/manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml
@@ -11,5 +11,4 @@ spec:
   extensions:
     - glusterfs
     - glusterfs-fuse
-    - qemu-guest-agent
     - NetworkManager-ovs

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,7 +52,6 @@ EXTENSION_RPMS=(
   python3-policycoreutils
   python3-setools
   python3-setuptools
-  qemu-guest-agent
   unbound-libs
   usbguard
   usbguard-selinux

--- a/manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml
+++ b/manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml
@@ -11,5 +11,4 @@ spec:
   extensions:
     - glusterfs
     - glusterfs-fuse
-    - qemu-guest-agent
     - NetworkManager-ovs

--- a/manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml
+++ b/manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml
@@ -11,5 +11,4 @@ spec:
   extensions:
     - glusterfs
     - glusterfs-fuse
-    - qemu-guest-agent
     - NetworkManager-ovs


### PR DESCRIPTION
Don't install `qemu-guest-agent` on the host - it should be setup via a daemonset preferably and managed by oVirt team.

This would allow us to run OCP->OKD and OKD->OCP upgrades