### PR TITLE
Revert "Dockerfile: use latest coreos assembler"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/openshift/origin-machine-config-operator:4.7 as mcd
 FROM quay.io/openshift/origin-artifacts:4.7 as artifacts
 
-FROM quay.io/coreos-assembler/coreos-assembler:master AS build
+FROM quay.io/coreos-assembler/coreos-assembler:v0.10.0 AS build
 COPY --from=mcd /usr/bin/machine-config-daemon /srv/addons/usr/libexec/machine-config-daemon
 COPY --from=artifacts /srv/repo/*.rpm /tmp/rpms/
 USER 0


### PR DESCRIPTION
Reverts openshift/okd-machine-os#80

Still breaks kubelet label: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/promote-release-openshift-okd-machine-os-content-e2e-aws-4.7/1358702467373600768