### PR TITLE
overlay: move ignition's ssh key to /home/core/.ssh/authorized_keys

### DIFF
--- a/bootstrap/overlay/var/home/core/.ssh/authorized_keys
+++ b/bootstrap/overlay/var/home/core/.ssh/authorized_keys
@@ -1,0 +1,1 @@
+/home/core/.ssh/authorized_keys.d/ignition

--- a/bootstrap/pre-pivot.sh
+++ b/bootstrap/pre-pivot.sh
@@ -5,6 +5,7 @@
 
 # Copy pivot files
 cp overlay/etc / -rvf
+cp overlay/var / -rvf
 cp overlay/usr/local/bin/* /usr/local/bin/ -rvf
 cp manifests/* /opt/openshift/openshift/ -rvf
 

--- a/overlay/etc/systemd/system/multi-user.target.wants/sync-ssh-key.service
+++ b/overlay/etc/systemd/system/multi-user.target.wants/sync-ssh-key.service
@@ -1,0 +1,1 @@
+../sync-ssh-key.service

--- a/overlay/etc/systemd/system/sync-ssh-key.service
+++ b/overlay/etc/systemd/system/sync-ssh-key.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Sync ssh key for MCO
+# Removal of this file signals firstboot completion
+ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
+# Skip if ssh key is already linked
+ConditionPathExists=/home/core/.ssh/authorized_keys.d/ignition
+ConditionPathExists=!/home/core/.ssh/authorized_keys
+[Service]
+Type=oneshot
+ExecStart=/bin/mv /home/core/.ssh/authorized_keys.d/ignition /home/core/.ssh/authorized_keys
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Fixes https://github.com/openshift/machine-config-operator/issues/2385