### PR TITLE
[release-4.6] Install CRI-O from OBS

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -exuo pipefail
 
-STREAM="stable"
+STREAM="next-devel"
 REF="fedora/x86_64/coreos/${STREAM}"
 
 # additional repos to use

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 set -exuo pipefail
 
-REPOS=()
 STREAM="stable"
 REF="fedora/x86_64/coreos/${STREAM}"
 
+# additional repos to use
+REPOS=()
 # additional RPMs to install via os-extensions
 EXTENSION_RPMS=(
   NetworkManager-ovs
@@ -109,30 +110,45 @@ dnf clean all
 ostree --repo=/srv/repo cat "${REF}" /usr/lib/os-release > /tmp/os-release
 source /tmp/os-release
 
+# Some repos are version-dependent
+CRIO_REPOS=(
+  https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/${CRIO_VERSION}/Fedora_${VERSION_ID}/
+)
+# TODO add cri-tools when its built for F33
+# https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Fedora_${VERSION_ID}/
+
 # prepare a list of repos to download packages from
 REPOLIST="--enablerepo=fedora --enablerepo=updates"
 for i in "${!REPOS[@]}"; do
   REPOLIST="${REPOLIST} --repofrompath=repo${i},${REPOS[$i]}"
 done
+for i in "${!CRIO_REPOS[@]}"; do
+  REPOLIST="${REPOLIST} --repofrompath=repo${i},${CRIO_REPOS[$i]}"
+done
+
+# yumdownloader params
+YUMD_PARAMS="--archlist=x86_64 --archlist=noarch --releasever=${VERSION_ID} ${REPOLIST}"
 
 # build extension repo
 mkdir /extensions
 pushd /extensions
   mkdir okd
-  yumdownloader --archlist=x86_64 --archlist=noarch --disablerepo='*' --destdir=/extensions/okd --releasever=${VERSION_ID} ${REPOLIST} ${EXTENSION_RPMS[*]}
+  yumdownloader ${YUMD_PARAMS} --destdir=/extensions/okd ${EXTENSION_RPMS[*]}
   createrepo_c --no-database .
 popd
+
+# download RPMs required on bootstrap node
+yumdownloader ${YUMD_PARAMS} --destdir=/tmp/rpms ${BOOTSTRAP_RPMS[*]}
+
+# download CRI-O RPMs
+# TODO: when a new cri-tools build is available remove enabling a module
+yumdownloader ${YUMD_PARAMS} --destdir=/tmp/rpms crio
+dnf module enable -y --enablerepo=updates-testing-modular cri-o:${CRIO_VERSION}
+yumdownloader ${YUMD_PARAMS} --destdir=/tmp/rpms --enablerepo=updates-testing-modular cri-tools
 
 # inject MCD binary and cri-o, hyperkube, and bootstrap RPMs in the ostree commit
 mkdir /tmp/working
 pushd /tmp/working
-  # enable crio
-  sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/fedora-updates-modular.repo
-  dnf module enable -y cri-o:${CRIO_VERSION}
-  yumdownloader --archlist=x86_64 --disablerepo='*' --destdir=/tmp/rpms --enablerepo=updates-modular cri-o cri-tools
-
-  yumdownloader --archlist=x86_64 --archlist=noarch --disablerepo='*' --destdir=/tmp/rpms  --releasever=${VERSION_ID} ${REPOLIST} ${BOOTSTRAP_RPMS[*]}
-
   for i in $(find /tmp/rpms/ -iname *.rpm); do
     echo "Extracting $i ..."
     rpm2cpio $i | cpio -div


### PR DESCRIPTION
Use published packages built on OBS instead of Fedora's bodhi and
modularity.

Fixes https://github.com/openshift/okd/issues/463