### PR TITLE
WIP Enable cgroupsv2

### DIFF
--- a/bootstrap/pre-pivot.sh
+++ b/bootstrap/pre-pivot.sh
@@ -25,6 +25,12 @@ MACHINE_CONFIG_OSCONTENT=$(image_for machine-os-content)
 echo "${MACHINE_CONFIG_OSCONTENT}" > /etc/pivot/image-pullspec
 touch /run/pivot/reboot-needed
 
+# Update bootstrap's kernel args
+echo -e "DELETE mitigations=auto,nosmt" > /etc/pivot/kernel-args
+echo -e "DELETE systemd.unified_cgroup_hierarchy=0" >> /etc/pivot/kernel-args
+echo -e "ADD cgroup_no_v1=all" >> /etc/pivot/kernel-args
+echo -e "ADD psi=1" /etc/pivot/kernel-args
+
 touch /opt/openshift/.pivot-done
 /usr/local/bin/machine-config-daemon pivot
 

--- a/manifests/99-okd-master-disable-mitigations.yaml
+++ b/manifests/99-okd-master-disable-mitigations.yaml
@@ -12,7 +12,7 @@ spec:
       files:
         - contents:
             source: >-
-              data:text/plain;charset=utf-8;base64,REVMRVRFIG1pdGlnYXRpb25zPWF1dG8sbm9zbXQ=
+              data:text/plain;charset=utf-8;base64,REVMRVRFIG1pdGlnYXRpb25zPWF1dG8sbm9zbXQKREVMRVRFIHN5c3RlbWQudW5pZmllZF9jZ3JvdXBfaGllcmFyY2h5PTAKQUREIGNncm91cF9ub192MT0iYWxsIgpBREQgcHNpPTEK
             verification: {}
           group: {}
           mode: 384

--- a/manifests/99-okd-worker-disable-mitigations.yaml
+++ b/manifests/99-okd-worker-disable-mitigations.yaml
@@ -12,7 +12,7 @@ spec:
       files:
         - contents:
             source: >-
-              data:text/plain;charset=utf-8;base64,REVMRVRFIG1pdGlnYXRpb25zPWF1dG8sbm9zbXQ=
+              data:text/plain;charset=utf-8;base64,REVMRVRFIG1pdGlnYXRpb25zPWF1dG8sbm9zbXQKREVMRVRFIHN5c3RlbWQudW5pZmllZF9jZ3JvdXBfaGllcmFyY2h5PTAKQUREIGNncm91cF9ub192MT0iYWxsIgpBREQgcHNpPTEK
             verification: {}
           group: {}
           mode: 384


### PR DESCRIPTION
bootstrap/manifests/99-okd-: add `DELETE systemd.unified_cgroup_hierarchy=0` in pivot's kernel-args

TODO:
* [ ] Update bootstrap's kernel args
* [ ] Allowlist psi / cgroup_no_v1 in MCO
* [x] Reconfigure crio to use crun / update runc in Fedora
      Not necessary, F34's runc works out of the box

Current status:
* [ ] Build tests are failing:
```
failed to retrieve cgroup limits: cannot determine cgroup limits: open /sys/fs/cgroup/memory/memory.limit_in_bytes: no such file or directory
```
https://bugzilla.redhat.com/show_bug.cgi?id=1949438