### PR TITLE
[release-4.6] Switch back to stable, add matching NetworkManager-ovs RPM

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -exuo pipefail
 
-STREAM="next-devel"
+STREAM="stable"
 REF="fedora/x86_64/coreos/${STREAM}"
 
 # additional repos to use

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,6 @@ REF="fedora/x86_64/coreos/${STREAM}"
 REPOS=()
 # additional RPMs to install via os-extensions
 EXTENSION_RPMS=(
-  NetworkManager-ovs
   checkpolicy
   dpdk
   gdbm-libs
@@ -134,6 +133,7 @@ mkdir /extensions
 pushd /extensions
   mkdir okd
   yumdownloader ${YUMD_PARAMS} --destdir=/extensions/okd ${EXTENSION_RPMS[*]}
+  curl -L -o /extensions/okd/NetworkManager-ovs-1.26.4-1.fc33.x86_64.rpm https://kojipkgs.fedoraproject.org//packages/NetworkManager/1.26.4/1.fc33/x86_64/NetworkManager-ovs-1.26.4-1.fc33.x86_64.rpm
   createrepo_c --no-database .
 popd
 


### PR DESCRIPTION
Switch back to "stable" channel and add a matching RPM version until stable commit catches up with NetworkManager update