### PR TITLE
[4.7] Switch to stable FCOS stream

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -exuo pipefail
 
 REPOS=()
-STREAM="next-devel"
+STREAM="stable"
 REF="fedora/x86_64/coreos/${STREAM}"
 
 # additional RPMs to install via os-extensions


### PR DESCRIPTION
OKD 4.7 is now stable so it should be using FCOS stable stream