### PR TITLE
[release-4.6] Revert "extensions: fetch NM-ovs version compatible with stable"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,7 @@ REF="fedora/x86_64/coreos/${STREAM}"
 REPOS=()
 # additional RPMs to install via os-extensions
 EXTENSION_RPMS=(
+  NetworkManager-ovs
   checkpolicy
   dpdk
   gdbm-libs
@@ -133,7 +134,6 @@ mkdir /extensions
 pushd /extensions
   mkdir okd
   yumdownloader ${YUMD_PARAMS} --destdir=/extensions/okd ${EXTENSION_RPMS[*]}
-  curl -L -o /extensions/okd/NetworkManager-ovs-1.26.4-1.fc33.x86_64.rpm https://kojipkgs.fedoraproject.org//packages/NetworkManager/1.26.4/1.fc33/x86_64/NetworkManager-ovs-1.26.4-1.fc33.x86_64.rpm
   createrepo_c --no-database .
 popd
 


### PR DESCRIPTION
This reverts commit d509b35a295410d734aa0bf96857bc8ef238c0e0.

FCOS stable was updated and includes compatible NM