### PR TITLE
Revert "Switch to stable FCOS stream"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -exuo pipefail
 
 REPOS=()
-STREAM="stable"
+STREAM="next-devel"
 REF="fedora/x86_64/coreos/${STREAM}"
 
 # additional RPMs to install via os-extensions


### PR DESCRIPTION
This reverts commit 1f396a5431598ce0cb8ba1d5810ea13f4f855d21.

This was accidentally merged after master started tracking 4.8. Latest master should use `next-devel`