### PR TITLE
manifests: add include.release annotations

### DIFF
--- a/manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml
+++ b/manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml
@@ -1,6 +1,9 @@
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     machineconfiguration.openshift.io/role: master
   name: 99-master-okd-extensions

--- a/manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml
+++ b/manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml
@@ -1,6 +1,9 @@
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     machineconfiguration.openshift.io/role: worker
   name: 99-worker-okd-extensions


### PR DESCRIPTION
Required to make CVO apply these manifests, so that we'd ensure all builds have necessary extensions installed