### PR TITLE
Dockerfile: use latest coreos assembler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/openshift/origin-machine-config-operator:4.7 as mcd
 FROM quay.io/openshift/origin-artifacts:4.7 as artifacts
 
-FROM quay.io/coreos-assembler/coreos-assembler:v0.10.0 AS build
+FROM quay.io/coreos-assembler/coreos-assembler:master AS build
 COPY --from=mcd /usr/bin/machine-config-daemon /srv/addons/usr/libexec/machine-config-daemon
 COPY --from=artifacts /srv/repo/*.rpm /tmp/rpms/
 USER 0


### PR DESCRIPTION
Reverts openshift/okd-machine-os#83.

All builds are now running on build02, which produces correct selinux labels on build