### PR TITLE
[release-4.7] overlay: add dhcp-client-identifier

### DIFF
--- a/bootstrap/overlay/etc/dhclient/dhclient.conf
+++ b/bootstrap/overlay/etc/dhclient/dhclient.conf
@@ -1,0 +1,1 @@
+send dhcp-client-identifier = hardware;

--- a/overlay/etc/dhclient/dhclient.conf
+++ b/overlay/etc/dhclient/dhclient.conf
@@ -1,0 +1,1 @@
+send dhcp-client-identifier = hardware;


### PR DESCRIPTION
This should resolve odd br-ex behaviour we're seeing with new NMs