### PR TITLE
manifests: ensure that bootstrap manifests are always updated by symlinking those

### DIFF
--- a/bootstrap/manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml
+++ b/bootstrap/manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml
@@ -1,15 +1,1 @@
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-  labels:
-    machineconfiguration.openshift.io/role: master
-  name: 99-master-okd-extensions
-spec:
-  config:
-    ignition:
-      version: 3.1.0
-  extensions:
-    - glusterfs
-    - glusterfs-fuse
-    - qemu-guest-agent
-    - NetworkManager-ovs
+../../manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml

--- a/bootstrap/manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml
+++ b/bootstrap/manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml
@@ -1,15 +1,1 @@
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-  labels:
-    machineconfiguration.openshift.io/role: worker
-  name: 99-worker-okd-extensions
-spec:
-  config:
-    ignition:
-      version: 3.1.0
-  extensions:
-    - glusterfs
-    - glusterfs-fuse
-    - qemu-guest-agent
-    - NetworkManager-ovs
+../../manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml


### PR DESCRIPTION
This would prevent a whole class of "real MCO fails to find rendered-.. manifests created by bootstrap manifests"