### PR TITLE
[release-4.7] add dhclient support for NM

### DIFF
--- a/bootstrap/manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml
+++ b/bootstrap/manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml
@@ -1,6 +1,9 @@
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     machineconfiguration.openshift.io/role: master
   name: 99-master-okd-extensions
@@ -9,7 +12,10 @@ spec:
     ignition:
       version: 3.1.0
   extensions:
+    - dhcp-client
+    - dhcp-common
     - glusterfs
     - glusterfs-fuse
+    - ipcalc
     - qemu-guest-agent
     - NetworkManager-ovs

--- a/bootstrap/manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml
+++ b/bootstrap/manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml
@@ -1,6 +1,9 @@
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     machineconfiguration.openshift.io/role: worker
   name: 99-worker-okd-extensions
@@ -9,7 +12,10 @@ spec:
     ignition:
       version: 3.1.0
   extensions:
+    - dhcp-client
+    - dhcp-common
     - glusterfs
     - glusterfs-fuse
+    - ipcalc
     - qemu-guest-agent
     - NetworkManager-ovs

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,11 +9,14 @@ REF="fedora/x86_64/coreos/${STREAM}"
 EXTENSION_RPMS=(
   NetworkManager-ovs
   checkpolicy
+  dhcp-client
+  dhcp-common
   dpdk
   gdbm-libs
   glusterfs
   glusterfs-client-xlators
   glusterfs-fuse
+  ipcalc
   kernel-devel
   kernel-headers
   libdrm

--- a/manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml
+++ b/manifests/0000_80_machine-config-operator_05_1_okd-master-extensions.yaml
@@ -12,7 +12,10 @@ spec:
     ignition:
       version: 3.1.0
   extensions:
+    - dhcp-client
+    - dhcp-common
     - glusterfs
     - glusterfs-fuse
+    - ipcalc
     - qemu-guest-agent
     - NetworkManager-ovs

--- a/manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml
+++ b/manifests/0000_80_machine-config-operator_05_2_okd-worker-extensions.yaml
@@ -12,7 +12,10 @@ spec:
     ignition:
       version: 3.1.0
   extensions:
+    - dhcp-client
+    - dhcp-common
     - glusterfs
     - glusterfs-fuse
+    - ipcalc
     - qemu-guest-agent
     - NetworkManager-ovs

--- a/overlay/etc/NetworkManager/conf.d/dhcp-client.conf
+++ b/overlay/etc/NetworkManager/conf.d/dhcp-client.conf
@@ -1,0 +1,2 @@
+[main]
+dhcp=dhclient


### PR DESCRIPTION
Have NM use dhclient instead of NM internal dhcp client.  This may reduce or eliminate the dhcp issues that have been reported.