### PR TITLE
Strip xattrs from RPM before unpacking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/openshift/origin-machine-config-operator:4.8 as mcd
 FROM quay.io/openshift/origin-artifacts:4.8 as artifacts
 
-FROM quay.io/coreos-assembler/coreos-assembler:v0.10.0 AS build
+FROM quay.io/coreos-assembler/coreos-assembler:latest AS build
 COPY --from=mcd /usr/bin/machine-config-daemon /srv/addons/usr/libexec/machine-config-daemon
 COPY --from=artifacts /srv/repo/*.rpm /tmp/rpms/
 USER 0


### PR DESCRIPTION
This ensures RPMs are fetched without xattrs, as rpm-ostree 2020.2 no longer accepts those.

Ref: https://github.com/openshift/okd/issues/566#issuecomment-802147697