### PR TITLE
Strip xattrs from drpms too

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -132,7 +132,7 @@ pushd /extensions
   mkdir okd
   yumdownloader ${YUMD_PARAMS} --destdir=/extensions/okd ${EXTENSION_RPMS[*]}
   # Strip problematic xattrs from extension RPMs
-  for i in $(find /extensions/okd -iname *.rpm); do
+  for i in $(find /extensions/okd -iname *.d*rpm); do
     fattr=$(getfattr -m 'user.*' $i)
     if [ -n "$fattr" ]; then
       attr=$(echo "$fattr" | grep -Ee '^user')
@@ -155,8 +155,8 @@ yumdownloader ${YUMD_PARAMS} --destdir=/tmp/rpms ${CRIO_RPMS[*]}
 # inject MCD binary and cri-o, hyperkube, and bootstrap RPMs in the ostree commit
 mkdir /tmp/working
 pushd /tmp/working
-# Strip problematic xattrs from extension RPMs
-  for i in $(find /tmp/rpms -iname *.rpm); do
+  # Strip problematic xattrs from extension RPMs
+  for i in $(find /tmp/rpms -iname *.d*rpm); do
     fattr=$(getfattr -m 'user.*' $i)
     if [ -n "$fattr" ]; then
       attr=$(echo "$fattr" | grep -Ee '^user')


### PR DESCRIPTION
Apr 09 09:10:47 ip-10-0-4-32 release-image-download.sh[1736]:         * error copying to host: error during bulk transfer for copier.request{Request:"PUT", Root:"/", preservedRoot:"/run/mco-machine-os-content/os-content-683856654", rootPrefix:"/run/mco-machine-os-content/os-content-683856654", Directory:"/", preservedDirectory:"/run/mco-machine-os-content/os-content-683856654", Globs:[]string{}, preservedGlobs:[]string{}, StatOptions:copier.StatOptions{CheckForArchives:false, Excludes:[]string(nil)}, GetOptions:copier.GetOptions{UIDMap:[]idtools.IDMap(nil), GIDMap:[]idtools.IDMap(nil), Excludes:[]string(nil), ExpandArchives:false, ChownDirs:(*idtools.IDPair)(nil), ChmodDirs:(*os.FileMode)(nil), ChownFiles:(*idtools.IDPair)(nil), ChmodFiles:(*os.FileMode)(nil), StripSetuidBit:false, StripSetgidBit:false, StripStickyBit:false, StripXattrs:false, KeepDirectoryNames:false, Rename:map[string]string(nil), NoDerefSymlinks:false, IgnoreUnreadable:false}, PutOptions:copier.PutOptions{UIDMap:[]idtools.IDMap(nil), GIDMap:[]idtools.IDMap(nil), DefaultDirOwner:(*idtools.IDPair)(nil), DefaultDirMode:(*os.FileMode)(nil), ChownDirs:(*idtools.IDPair)(0xc00040c3a0), ChmodDirs:(*os.FileMode)(nil), ChownFiles:(*idtools.IDPair)(0xc00040c420), ChmodFiles:(*os.FileMode)(nil), StripXattrs:false, IgnoreXattrErrors:false, IgnoreDevices:true, NoOverwriteDirNonDir:false, Rename:map[string]string(nil)}, MkdirOptions:copier.MkdirOptions{UIDMap:[]idtools.IDMap(nil), GIDMap:[]idtools.IDMap(nil), ChownNew:(*idtools.IDPair)(nil), ChmodNew:(*os.FileMode)(nil)}}: copier: put: error setting extended attributes on "/extensions/okd/perl-Errno-1.30-468.fc33_1.30-469.fc33.x86_64.drpm": error setting value of extended attribute "user.Zif.MdChecksum[1617881158]" on "/extensions/okd/perl-Errno-1.30-468.fc33_1.30-469.fc33.x86_64.drpm": operation not supported