### PR TITLE
Pin NetworkManager-ovs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,9 +5,12 @@ REPOS=()
 STREAM="stable"
 REF="fedora/x86_64/coreos/${STREAM}"
 
+RPMS_FROM_FEDORA_UPDATES_ARCHIVE=(
+  NetworkManager-ovs-1:1.26.6-1.fc33.x86_64
+)
+
 # additional RPMs to install via os-extensions
 EXTENSION_RPMS=(
-  NetworkManager-ovs
   checkpolicy
   dpdk
   gdbm-libs
@@ -123,6 +126,8 @@ YUMD_PARAMS="--archlist=x86_64 --archlist=noarch --releasever=${VERSION_ID} ${RE
 mkdir /extensions
 pushd /extensions
   mkdir okd
+  # Some RPMS need to be fetched from updates-archive
+  yumdownloader ${YUMD_PARAMS} --enablerepo=updates-archive --destdir=/extensions/okd ${RPMS_FROM_FEDORA_UPDATES_ARCHIVE[*]}
   yumdownloader ${YUMD_PARAMS} --destdir=/extensions/okd ${EXTENSION_RPMS[*]}
   # Strip problematic xattrs from extension RPMs
   for i in $(find /extensions/okd -iname *.rpm); do


### PR DESCRIPTION
FCOS stable may have older packages, no longer available in fedora-update. Look those up in fedora-update-archives