### PR TITLE
WIP okd-packages: don't install glusterfs

### DIFF
--- a/okd-packages.yaml
+++ b/okd-packages.yaml
@@ -2,8 +2,6 @@ packages:
 - NetworkManager-ovs
 - open-vm-tools
 - qemu-guest-agent
-- glusterfs
-- glusterfs-fuse
 - crio
 - cri-tools
 - openshift-hyperkube


### PR DESCRIPTION
These are no longer needed, as GlusterFS tests are now being skipped