### PR TITLE
Pin selinux-policy and avoid updating lock-files

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ pushd /srv/okd-repo
 popd
 
 # build ostree commit
-cosa fetch --update-lockfile
+cosa fetch
 cosa build ostree
 
 echo "Building container"

--- a/manifest-lock.x86_64.json
+++ b/manifest-lock.x86_64.json
@@ -1,0 +1,1 @@
+fedora-coreos-config/manifest-lock.x86_64.json


### PR DESCRIPTION
Prevent selinux-policy 34.9 from being installed, as it breaks crio