### PR TITLE
Set DNS stub listener

### DIFF
--- a/overlay.d/99okd/etc/systemd/resolved.conf.d/okd-no-dns-stub.conf
+++ b/overlay.d/99okd/etc/systemd/resolved.conf.d/okd-no-dns-stub.conf
@@ -1,0 +1,3 @@
+# Kubelet can't work with systemd-resolved just yet
+[Resolve]
+DNSStubListener=no


### PR DESCRIPTION
overlay: make sure we explicitely disable DNS Stub Listener

FCOS may reverse it decision landing dns stub, but its should be independent of OKD. Ensure that this config setting is set.

Ref: https://github.com/openshift/okd/issues/690