### PR TITLE
Dockerfiles: /extensions needs to be a valid RPM repo

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,8 +1,8 @@
 FROM INITIAL_IMAGE as oscontainer
 FROM scratch
 COPY --from=oscontainer /srv/ /srv/
+COPY --from=oscontainer /extensions/ /extensions/
 COPY manifests/ /manifests/
 COPY bootstrap/ /bootstrap/
-COPY extensions/ /extensions/
 LABEL io.openshift.release.operator=true
 ENTRYPOINT ["/noentry"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,5 +22,11 @@ popd
 cosa fetch
 cosa build ostree
 
+# Create repo for OS Extensions
+mkdir -p /overlay/extensions
+pushd /overlay/extensions
+  createrepo_c .
+popd
+
 echo "Building container"
-cosa upload-oscontainer --name "quay.io/vrutkovs/okd-os"
+cosa upload-oscontainer --name "quay.io/vrutkovs/okd-os" --add-directory /overlay


### PR DESCRIPTION
Use `createrepo` util in cosa container to have `/extensions` created as a valid repo, as MCD requires that when os extensions are installed