### PR TITLE
[release-4.7] manifests: unset OKD extensions

### DIFF
--- a/manifests/99-master-okd-extensions.yaml
+++ b/manifests/99-master-okd-extensions.yaml
@@ -1,0 +1,14 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: 'true'
+    include.release.openshift.io/single-node-developer: 'true'
+  name: 99-master-okd-extensions
+  labels:
+    machineconfiguration.openshift.io/role: master
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+  extensions: []

--- a/manifests/99-worker-okd-extensions.yaml
+++ b/manifests/99-worker-okd-extensions.yaml
@@ -1,0 +1,14 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: 'true'
+    include.release.openshift.io/single-node-developer: 'true'
+  name: 99-master-okd-extensions
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+  extensions: []


### PR DESCRIPTION
OKD no longer requires OS extensions to run and includes them in the base image. This would ensure 99-master/worker-okd-extensions MCs no longer list those