### PR TITLE
manifests: fix a typo in worker extensions list

### DIFF
--- a/manifests/99-worker-okd-extensions.yaml
+++ b/manifests/99-worker-okd-extensions.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: 'true'
     include.release.openshift.io/single-node-developer: 'true'
-  name: 99-master-okd-extensions
+  name: 99-worker-okd-extensions
   labels:
     machineconfiguration.openshift.io/role: worker
 spec:


### PR DESCRIPTION
Fix a typo in 99-worker-okd-extensions name