### PR TITLE
Fasttrack selinux-policy 34.11-1.fc34

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -36,3 +36,9 @@ packages:
         evr: 1:1.32.1-28600.copr.b5de7b2e48.fc34
     NetworkManager-team:
         evr: 1:1.32.1-28600.copr.b5de7b2e48.fc34
+    # Fast-track SELinux fix for systemd-hostnamed
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1953060
+    selinux-policy:
+        evr: 34.11-1.fc34
+    selinux-policy-targeted:
+        evr: 34.11-1.fc34


### PR DESCRIPTION
Fixes https://github.com/openshift/okd/issues/709.

Systemd-hostnamed selinux permissions are fixed in https://bugzilla.redhat.com/show_bug.cgi?id=1953060