### PR TITLE
[release-4.7] manifests: add CVO annotations

### DIFF
--- a/manifests/99-okd-master-disable-mitigations.yaml
+++ b/manifests/99-okd-master-disable-mitigations.yaml
@@ -1,6 +1,10 @@
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     machineconfiguration.openshift.io/role: master
   name: 99-okd-master-disable-mitigations

--- a/manifests/99-okd-worker-disable-mitigations.yaml
+++ b/manifests/99-okd-worker-disable-mitigations.yaml
@@ -1,6 +1,10 @@
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     machineconfiguration.openshift.io/role: worker
   name: 99-okd-worker-disable-mitigations


### PR DESCRIPTION
This ensures the manifests are being synced by CVO.

Cherry-pick of #154 on `release-4.7`. Fixes https://github.com/openshift/okd/issues/710