### PR TITLE
[WIP][4.7][4.8] Remove 'search .' from /run/systemd/resolve/resolv.conf 

### DIFF
--- a/overlay.d/99okd/usr/lib/systemd/system-preset/00-okd.preset
+++ b/overlay.d/99okd/usr/lib/systemd/system-preset/00-okd.preset
@@ -1,4 +1,6 @@
 # Fetch GCP hostnames via afterburn
 enable gcp-hostnames.service
+# Remove "search ." from /run/systemd/resolve/resolv.conf if it exists
+enable fix-resolv-conf-search.service
 # Skip cgroups warning
 disable coreos-check-cgroups.service

--- a/overlay.d/99okd/usr/lib/systemd/system/fix-resolv-conf-search.service
+++ b/overlay.d/99okd/usr/lib/systemd/system/fix-resolv-conf-search.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Remove search . from /etc/resolv.conf
+DefaultDependencies=no
+Requires=systemd-resolved.service
+After=systemd-resolved.service
+BindsTo=systemd-resolved.service
+
+[Service]
+Type=oneshot
+ExecStartPre=/usr/bin/sleep 5
+ExecStart=/usr/bin/sed -i -e "s/^search .$//" /run/systemd/resolve/resolv.conf
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
In FCOS 33, if OKD is created with static IPs via kernel arguments the DNS a domain not created resulting in an /etc/resolv.conf without a search entry. This is handled by systemd-resolved

FCOS 33 uses systemd-246.14-1.fc33

If FCOS 34 this behavior changed and now systems with static IPs via kernel args and no DNS domain have a line search . added like this
```
nameserver 10.99.111.1
nameserver 10.99.111.2
search .
```
This was introduced with: systemd/systemd#17201

FCOS 34 uses systemd-248.3-1.fc34 which includes the above 'enhancement'

Unfortunately this seems to causes a problem with OKD cluster DNS resolution as cluster domains no longer seem to work. Adding new element results in issues such as

openshift/okd#694

Get "https://image-registry.openshift-image-registry.svc:5000/v2/": dial tcp: lookup image-registry.openshift-image-registry.svc on 10.10.8.132:53: no such host