### PR TITLE
[release-4.7] Undo systemd-resolved change in https://github.com/systemd/systemd/pu…

### DIFF
--- a/overlay.d/99okd/usr/lib/systemd/system-preset/00-okd.preset
+++ b/overlay.d/99okd/usr/lib/systemd/system-preset/00-okd.preset
@@ -1,4 +1,6 @@
 # Fetch GCP hostnames via afterburn
 enable gcp-hostnames.service
+# Remove "search ." from /run/systemd/resolve/resolv.conf if it exists
+enable fix-resolv-conf-search.service
 # Skip cgroups warning
 disable coreos-check-cgroups.service

--- a/overlay.d/99okd/usr/lib/systemd/system/fix-resolv-conf-search.service
+++ b/overlay.d/99okd/usr/lib/systemd/system/fix-resolv-conf-search.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Remove search . from /etc/resolv.conf
+DefaultDependencies=no
+Requires=systemd-resolved.service
+After=systemd-resolved.service
+BindsTo=systemd-resolved.service
+
+[Service]
+Type=oneshot
+ExecStartPre=/usr/bin/sleep 5
+ExecStart=/usr/bin/sed -i -e "s/^search .$//" /run/systemd/resolve/resolv.conf
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
…ll/17201

This was introduced inn Fedora 34 systemd-248.3-1.fc34.
This breaks internal DNS resolution in the OKD cluster.

Signed-off-by: John Fortin <fortinj66@gmail.com>

Cherry-pick of #159 on release-4.7