### PR TITLE
[release-4.7] Bump fedora-coreos-config

### DIFF
--- a/fedora-updates-archive.repo
+++ b/fedora-updates-archive.repo
@@ -1,0 +1,11 @@
+[updates-archive]
+name=Fedora $releasever - $basearch - Updates Archive
+baseurl=https://fedoraproject-updates-archive.fedoraproject.org/fedora/$releasever/$basearch/
+enabled=1
+metadata_expire=6h
+repo_gpgcheck=0
+type=rpm
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+skip_if_unavailable=True
+cost=10000 # default is 1000

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -1,38 +1,47 @@
 packages:
-    # Freeze dracut on 053. We need to investigate NetworkManager systemd changes.
-    # https://github.com/coreos/fedora-coreos-tracker/issues/842
-    dracut:
-        evr: 053-5.fc34
-    dracut-network:
-        evr: 053-5.fc34
-    # Fast-track crun-0.19.1-3.fc34 It was erroneously downgraded in Fedora.
-    # https://bodhi.fedoraproject.org/updates/FEDORA-2021-316efff8f2
-    crun:
-        evr: 0.19.1-3.fc34
-    # Fast-track new coreos-installer release
-    # https://bodhi.fedoraproject.org/updates/FEDORA-2021-46c72bed26
-    coreos-installer:
-        evr: 0.9.1-1.fc34
-    coreos-installer-bootinfra:
-        evr: 0.9.1-1.fc34
-    # For CVE-2021-30465 (symlink exchange attack)
-    # https://bodhi.fedoraproject.org/updates/FEDORA-2021-0440f235a0
-    runc:
-        evr: 2:1.0.0-378.rc95.fc34
-    # For firstboot multipath
-    # https://bodhi.fedoraproject.org/updates/FEDORA-2021-123bd6e0dc
-    ignition:
-        evr: 2.10.1-3.fc34
-    # https://github.com/openshift/okd/issues/648
-    NetworkManager:
-        evr: 1:1.32.1-28600.copr.b5de7b2e48.fc34
-    NetworkManager-libnm:
-        evr: 1:1.32.1-28600.copr.b5de7b2e48.fc34
-    NetworkManager-ovs:
-        evr: 1:1.32.1-28600.copr.b5de7b2e48.fc34
-    NetworkManager-tui:
-        evr: 1:1.32.1-28600.copr.b5de7b2e48.fc34
-    NetworkManager-cloud-setup:
-        evr: 1:1.32.1-28600.copr.b5de7b2e48.fc34
-    NetworkManager-team:
-        evr: 1:1.32.1-28600.copr.b5de7b2e48.fc34
+  dracut:
+    evr: 053-5.fc34
+    metadata:
+      type: pin
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/842
+  dracut-network:
+    evr: 053-5.fc34
+    metadata:
+      type: pin
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/842
+  ignition:
+    evr: 2.10.1-3.fc34
+    metadata:
+      type: fast-track
+      reason: https://github.com/coreos/fedora-coreos-config/pull/1011
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-123bd6e0dc
+  NetworkManager:
+    evr: 1:1.32.3-28651.copr.d90baeecd8.fc34
+    metadata:
+      reason: https://github.com/openshift/okd/issues/648
+      type: pin
+  NetworkManager-libnm:
+    evr: 1:1.32.3-28651.copr.d90baeecd8.fc34
+    metadata:
+      reason: https://github.com/openshift/okd/issues/648
+      type: pin
+  NetworkManager-ovs:
+    evr: 1:1.32.3-28651.copr.d90baeecd8.fc34
+    metadata:
+      reason: https://github.com/openshift/okd/issues/648
+      type: pin
+  NetworkManager-tui:
+    evr: 1:1.32.3-28651.copr.d90baeecd8.fc34
+    metadata:
+      reason: https://github.com/openshift/okd/issues/648
+      type: pin
+  NetworkManager-cloud-setup:
+    evr: 1:1.32.3-28651.copr.d90baeecd8.fc34
+    metadata:
+      reason: https://github.com/openshift/okd/issues/648
+      type: pin
+  NetworkManager-team:
+    evr: 1:1.32.3-28651.copr.d90baeecd8.fc34
+    metadata:
+      reason: https://github.com/openshift/okd/issues/648
+      type: pin

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -45,3 +45,23 @@ packages:
     metadata:
       reason: https://github.com/openshift/okd/issues/648
       type: pin
+  selinux-policy:
+    evr: 34.8-1.fc34
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=1980693
+      type: pin
+  selinux-policy-targeted:
+    evr: 34.8-1.fc34
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=1980693
+      type: pin
+  selinux-policy:
+    evr: 34.8-1.fc34
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=1980693
+      type: pin
+  container-selinux:
+    evr: 2:2.162.1-3.fc34
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=1980693
+      type: pin

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -14,6 +14,7 @@ ref: fedora/${basearch}/coreos/okd
 repos:
   - fedora
   - fedora-updates
+  - updates-archive
   - fedora-coreos-pool
   - copr:copr.fedorainfracloud.org:networkmanager:NetworkManager-1.32
   - crio


### PR DESCRIPTION
Update to latest stable Fedora CoreOS config, update NetworkManager and pin `selinux-policy`