### PR TITLE
overlay: ensure machines have qemu-guest-agent enabled

### DIFF
--- a/overlay.d/99okd/usr/lib/systemd/system-preset/00-okd.preset
+++ b/overlay.d/99okd/usr/lib/systemd/system-preset/00-okd.preset
@@ -4,3 +4,5 @@ enable gcp-hostnames.service
 enable fix-resolv-conf-search.service
 # Skip cgroups warning
 disable coreos-check-cgroups.service
+# Enable ovirt service
+enable qemu-guest-agent.service

--- a/overlay.d/99okd/usr/lib/systemd/system/fix-resolv-conf-search.service
+++ b/overlay.d/99okd/usr/lib/systemd/system/fix-resolv-conf-search.service
@@ -9,6 +9,7 @@ BindsTo=systemd-resolved.service
 Type=oneshot
 ExecStartPre=/usr/bin/sleep 5
 ExecStart=/usr/bin/sed -i -e "s/^search .$//" /run/systemd/resolve/resolv.conf
+ExecStart=/usr/bin/cp /run/systemd/resolve/resolv.conf /var/run/NetworkManager/resolv.conf
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This is required for machines to report valid IP on oVirt