### PR TITLE
bootstrap manifests: update Ignition version

### DIFF
--- a/manifests/99-master-okd-extensions.yaml
+++ b/manifests/99-master-okd-extensions.yaml
@@ -10,5 +10,5 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
   extensions: []

--- a/manifests/99-okd-master-disable-mitigations.yaml
+++ b/manifests/99-okd-master-disable-mitigations.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
     storage:
       files:
         - contents:

--- a/manifests/99-okd-worker-disable-mitigations.yaml
+++ b/manifests/99-okd-worker-disable-mitigations.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
     storage:
       files:
         - contents:

--- a/manifests/99-worker-okd-extensions.yaml
+++ b/manifests/99-worker-okd-extensions.yaml
@@ -10,5 +10,5 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
   extensions: []


### PR DESCRIPTION
Other installer components are using 3.2.0