### PR TITLE
[release-4.8] bootstrap/manifests: set CVO annotations

### DIFF
--- a/manifests/99-master-okd-extensions.yaml
+++ b/manifests/99-master-okd-extensions.yaml
@@ -2,8 +2,9 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   annotations:
-    include.release.openshift.io/self-managed-high-availability: 'true'
-    include.release.openshift.io/single-node-developer: 'true'
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: 99-master-okd-extensions
   labels:
     machineconfiguration.openshift.io/role: master

--- a/manifests/99-okd-community-operators.yaml
+++ b/manifests/99-okd-community-operators.yaml
@@ -2,6 +2,10 @@ apiVersion: config.openshift.io/v1
 kind: OperatorHub
 metadata:
   name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   disableAllDefaultSources: true
   sources: [

--- a/manifests/99-okd-community-operators.yaml
+++ b/manifests/99-okd-community-operators.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
 spec:
   disableAllDefaultSources: true
   sources: [

--- a/manifests/99-worker-okd-extensions.yaml
+++ b/manifests/99-worker-okd-extensions.yaml
@@ -2,8 +2,9 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   annotations:
-    include.release.openshift.io/self-managed-high-availability: 'true'
-    include.release.openshift.io/single-node-developer: 'true'
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   name: 99-worker-okd-extensions
   labels:
     machineconfiguration.openshift.io/role: worker


### PR DESCRIPTION
Make sure all manifests have necessary annotations. Cherry-pick of #176 on release-4.8