### PR TITLE
overrides: remove NM override

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -1,45 +1,10 @@
 packages:
-  NetworkManager:
-    evr: 1:1.32.11-28754.copr.dd8bc31fdb.fc34
-    metadata:
-      reason: https://github.com/openshift/okd/issues/648
-      type: pin
-  NetworkManager-libnm:
-    evr: 1:1.32.11-28754.copr.dd8bc31fdb.fc34
-    metadata:
-      reason: https://github.com/openshift/okd/issues/648
-      type: pin
-  NetworkManager-ovs:
-    evr: 1:1.32.11-28754.copr.dd8bc31fdb.fc34
-    metadata:
-      reason: https://github.com/openshift/okd/issues/648
-      type: pin
-  NetworkManager-tui:
-    evr: 1:1.32.11-28754.copr.dd8bc31fdb.fc34
-    metadata:
-      reason: https://github.com/openshift/okd/issues/648
-      type: pin
-  NetworkManager-cloud-setup:
-    evr: 1:1.32.11-28754.copr.dd8bc31fdb.fc34
-    metadata:
-      reason: https://github.com/openshift/okd/issues/648
-      type: pin
-  NetworkManager-team:
-    evr: 1:1.32.11-28754.copr.dd8bc31fdb.fc34
-    metadata:
-      reason: https://github.com/openshift/okd/issues/648
-      type: pin
   selinux-policy:
     evr: 34.8-1.fc34
     metadata:
       reason: https://bugzilla.redhat.com/show_bug.cgi?id=1980693
       type: pin
   selinux-policy-targeted:
-    evr: 34.8-1.fc34
-    metadata:
-      reason: https://bugzilla.redhat.com/show_bug.cgi?id=1980693
-      type: pin
-  selinux-policy:
     evr: 34.8-1.fc34
     metadata:
       reason: https://bugzilla.redhat.com/show_bug.cgi?id=1980693


### PR DESCRIPTION
Current NM build has been pruned, newer NM 1.32 builds require updated glibc, blocked by selinux pin