### PR TITLE
overlay: add NetworkManager config to prevent requesting additional MAC

### DIFF
--- a/overlay.d/99okd/etc/dhclient/dhclient.conf
+++ b/overlay.d/99okd/etc/dhclient/dhclient.conf
@@ -1,1 +1,0 @@
-send dhcp-client-identifier = hardware;

--- a/overlay.d/99okd/etc/systemd/network/98-ovs-mac.link
+++ b/overlay.d/99okd/etc/systemd/network/98-ovs-mac.link
@@ -1,0 +1,5 @@
+[Match]
+Driver=openvswitch
+
+[Link]
+MACAddressPolicy=none


### PR DESCRIPTION
Replaces the dhclient config overlay.

Restores #108 (which fixes https://github.com/openshift/okd/issues/540)