### PR TITLE
[release-4.7] overlay: add NetworkManager config to prevent requesting additional MAC

### DIFF
--- a/overlay.d/99okd/etc/systemd/network/98-ovs-mac.link
+++ b/overlay.d/99okd/etc/systemd/network/98-ovs-mac.link
@@ -1,0 +1,5 @@
+[Match]
+Driver=openvswitch
+
+[Link]
+MACAddressPolicy=none


### PR DESCRIPTION
Replaces the dhclient config overlay.

Restores openshift#108 (which fixes openshift/okd#540)

Co-Authored-By: Christian Glombek <13365531+LorbusChris@users.noreply.github.com>