### PR TITLE
overlay: Disable zincati.service via dropin on bootstrap node

### DIFF
--- a/bootstrap/overlay/etc/systemd/system/zincati.service.d/okd-machine-os-disabled.conf
+++ b/bootstrap/overlay/etc/systemd/system/zincati.service.d/okd-machine-os-disabled.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/enoent


### PR DESCRIPTION
Restore dropin conf for disabling Zincati, that was unintentionally removed in https://github.com/openshift/okd-machine-os/pull/117

Reported in https://github.com/openshift/okd/issues/898