### PR TITLE
[release-4.9] Dockerfile: set io.openshift.build.versions

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,5 +4,7 @@ COPY --from=oscontainer /srv/ /srv/
 COPY --from=oscontainer /extensions/ /extensions/
 COPY manifests/ /manifests/
 COPY bootstrap/ /bootstrap/
-LABEL io.openshift.release.operator=true
+LABEL io.openshift.release.operator=true \
+      io.openshift.build.version-display-names="machine-os=Fedora CoreOS" \
+      io.openshift.build.versions="machine-os=49.34.0"
 ENTRYPOINT ["/noentry"]


### PR DESCRIPTION
Set this version to a static value, later on can be extended to a kubelet/crio version