### PR TITLE
[release-4.8] Dockerfile: replace machine-os version with build ID, add crio and kubelet versions

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,15 +2,4 @@ FROM quay.io/vrutkovs/cirrus-run
 WORKDIR /go/src/github.com/openshift/okd-machine-os
 COPY . .
 # Build Dockerfile.cosa in Cirrus CI
-RUN export OPENSHIFT_BUILD_REFERENCE=$(git rev-parse FETCH_HEAD) && \
-    export FETCH_HEAD_CONTENT="$(cat ./.git/FETCH_HEAD)" && \
-    export OPENSHIFT_BUILD_SOURCE="${FETCH_HEAD_CONTENT##* }" && \
-    echo "Building ${OPENSHIFT_BUILD_REFERENCE} in ${OPENSHIFT_BUILD_SOURCE}" && \
-    set -o pipefail && \
-    cirrus-run --github vrutkovs/okd-os --branch main --show-build-log always | tee /tmp/build.log && \
-    # replace resulting image in Dockerfile
-    IMAGE=$(grep "Committing container" -A1 /tmp/build.log | tail -n1 | tr ' ' '\n' | head -n1) && \
-    sed "s;INITIAL_IMAGE;${IMAGE};g" Dockerfile.template > /tmp/Dockerfile && \
-    IMAGE=$(grep -oP "New build ID: \K.*" /tmp/build.log) && \
-    sed -i "s;OSTREE_VERSION;${OSTREE_VERSION}" /tmp/Dockerfile && \
-    mkdir ./extensions
+RUN sh build.sh

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -11,4 +11,6 @@ RUN export OPENSHIFT_BUILD_REFERENCE=$(git rev-parse FETCH_HEAD) && \
     # replace resulting image in Dockerfile
     IMAGE=$(grep "Committing container" -A1 /tmp/build.log | tail -n1 | tr ' ' '\n' | head -n1) && \
     sed "s;INITIAL_IMAGE;${IMAGE};g" Dockerfile.template > /tmp/Dockerfile && \
+    IMAGE=$(grep -oP "New build ID: \K.*" /tmp/build.log) && \
+    sed -i "s;OSTREE_VERSION;${OSTREE_VERSION}" /tmp/Dockerfile && \
     mkdir ./extensions

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,6 +5,6 @@ COPY --from=oscontainer /extensions/ /extensions/
 COPY manifests/ /manifests/
 COPY bootstrap/ /bootstrap/
 LABEL io.openshift.release.operator=true \
-      io.openshift.build.version-display-names="machine-os=Fedora CoreOS" \
-      io.openshift.build.versions="machine-os=OSTREE_VERSION"
+      io.openshift.build.version-display-names="machine-os=Fedora CoreOS,cri-o=CRI-O,kubelet=Kubelet" \
+      io.openshift.build.versions="machine-os=OSTREE_VERSION,cri-o=CRIO_RPM,kubelet=HYPERKUBE_RPM"
 ENTRYPOINT ["/noentry"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,5 +6,5 @@ COPY manifests/ /manifests/
 COPY bootstrap/ /bootstrap/
 LABEL io.openshift.release.operator=true \
       io.openshift.build.version-display-names="machine-os=Fedora CoreOS" \
-      io.openshift.build.versions="machine-os=48.34.0"
+      io.openshift.build.versions="machine-os=OSTREE_VERSION"
 ENTRYPOINT ["/noentry"]

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -exuo pipefail
+export OPENSHIFT_BUILD_REFERENCE=$(git rev-parse FETCH_HEAD)
+export FETCH_HEAD_CONTENT="$(cat ./.git/FETCH_HEAD)"
+export OPENSHIFT_BUILD_SOURCE="${FETCH_HEAD_CONTENT##* }"
+
+
+echo "Building ${OPENSHIFT_BUILD_REFERENCE} in ${OPENSHIFT_BUILD_SOURCE}"
+cirrus-run --github vrutkovs/okd-os --branch main --show-build-log always | tee /tmp/build.log
+
+INITIAL_IMAGE=$(grep "Committing container" -A1 /tmp/build.log | tail -n1 | tr ' ' '\n' | head -n1)
+sed "s;INITIAL_IMAGE;${INITIAL_IMAGE};g" Dockerfile.template > /tmp/Dockerfile
+
+OSTREE_VERSION="$(grep "OSTREE_VERSION" /tmp/build.log | cut -d'=' -f2)"
+sed -i "s;OSTREE_VERSION;${OSTREE_VERSION};g" /tmp/Dockerfile
+
+CRIO_RPM="$(grep -m1 -o "cri-o-\S*" /tmp/build.log | sed 's;cri-o-\(.*\).x86_64;\1;g')"
+sed -i "s;CRIO_RPM;${CRIO_RPM};g" /tmp/Dockerfile
+
+HYPERKUBE_RPM="$(grep -m1 -o "openshift-hyperkube-\S*" /tmp/build.log | sed 's;openshift-hyperkube-\(.*\).x86_64;\1;g')"
+sed -i "s;HYPERKUBE_RPM;${HYPERKUBE_RPM};g" /tmp/Dockerfile
+
+mkdir ./extensions


### PR DESCRIPTION
Save more info about the build in machine-os-content labels so that this information would show up on nightlies page