### PR TITLE
[release-4.9] disable-mitigations config: don't reset cgroupsv2 karg

### DIFF
--- a/bootstrap/overlay/etc/pivot/kernel-args
+++ b/bootstrap/overlay/etc/pivot/kernel-args
@@ -1,2 +1,1 @@
-ADD systemd.unified_cgroup_hierarchy=0
 DELETE mitigations=auto,nosmt

--- a/manifests/99-okd-master-disable-mitigations.yaml
+++ b/manifests/99-okd-master-disable-mitigations.yaml
@@ -16,7 +16,7 @@ spec:
       files:
         - contents:
             source: >-
-              data:text/plain;charset=utf-8;base64,REVMRVRFIG1pdGlnYXRpb25zPWF1dG8sbm9zbXQKQUREIHN5c3RlbWQudW5pZmllZF9jZ3JvdXBfaGllcmFyY2h5PTAK
+              data:text/plain;charset=utf-8;base64,REVMRVRFIG1pdGlnYXRpb25zPWF1dG8sbm9zbXQK
             verification: {}
           group: {}
           mode: 384

--- a/manifests/99-okd-worker-disable-mitigations.yaml
+++ b/manifests/99-okd-worker-disable-mitigations.yaml
@@ -16,7 +16,7 @@ spec:
       files:
         - contents:
             source: >-
-              data:text/plain;charset=utf-8;base64,REVMRVRFIG1pdGlnYXRpb25zPWF1dG8sbm9zbXQKQUREIHN5c3RlbWQudW5pZmllZF9jZ3JvdXBfaGllcmFyY2h5PTAK
+              data:text/plain;charset=utf-8;base64,REVMRVRFIG1pdGlnYXRpb25zPWF1dG8sbm9zbXQK
             verification: {}
           group: {}
           mode: 384


### PR DESCRIPTION
Use system's cgroupsv2 setting, so that cgroupsv2 would be enabled on new installs and not overwritten on upgrades