### PR TITLE
Enable cgroupsv2 for OKD 4.10

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "gitsubmodules"
+  - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
       interval: "daily"

--- a/bootstrap/overlay/etc/pivot/kernel-args
+++ b/bootstrap/overlay/etc/pivot/kernel-args
@@ -1,2 +1,2 @@
-ADD systemd.unified_cgroup_hierarchy=0
+ADD systemd.unified_cgroup_hierarchy=1
 DELETE mitigations=auto,nosmt

--- a/manifests/99-okd-master-disable-mitigations.yaml
+++ b/manifests/99-okd-master-disable-mitigations.yaml
@@ -16,7 +16,7 @@ spec:
       files:
         - contents:
             source: >-
-              data:text/plain;charset=utf-8;base64,REVMRVRFIG1pdGlnYXRpb25zPWF1dG8sbm9zbXQKQUREIHN5c3RlbWQudW5pZmllZF9jZ3JvdXBfaGllcmFyY2h5PTAK
+              data:text/plain;charset=utf-8;base64,REVMRVRFIG1pdGlnYXRpb25zPWF1dG8sbm9zbXQKQUREIHN5c3RlbWQudW5pZmllZF9jZ3JvdXBfaGllcmFyY2h5PTEK
             verification: {}
           group: {}
           mode: 384

--- a/manifests/99-okd-worker-disable-mitigations.yaml
+++ b/manifests/99-okd-worker-disable-mitigations.yaml
@@ -16,7 +16,7 @@ spec:
       files:
         - contents:
             source: >-
-              data:text/plain;charset=utf-8;base64,REVMRVRFIG1pdGlnYXRpb25zPWF1dG8sbm9zbXQKQUREIHN5c3RlbWQudW5pZmllZF9jZ3JvdXBfaGllcmFyY2h5PTAK
+              data:text/plain;charset=utf-8;base64,REVMRVRFIG1pdGlnYXRpb25zPWF1dG8sbm9zbXQKQUREIHN5c3RlbWQudW5pZmllZF9jZ3JvdXBfaGllcmFyY2h5PTEK
             verification: {}
           group: {}
           mode: 384


### PR DESCRIPTION
Use cgroupsv2 for new installs and updated clusters.

Also fixes a typo in dependabot config