### PR TITLE
[release-4.7] Bump fedora-coreos-config to latest stable

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -26,13 +26,9 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-3d52eb54ca
       reason: https://github.com/coreos/coreos-installer/security/advisories/GHSA-3r3g-g73x-g593
       type: fast-track
-  rpm-ostree:
-    evr: 2021.11-2.fc34
+  ignition:
+    evr: 2.12.0-3.fc34
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-03a5539124
-      type: fast-track
-  rpm-ostree-libs:
-    evr: 2021.11-2.fc34
-    metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-03a5539124
+      bodhi:  https://bodhi.fedoraproject.org/updates/FEDORA-2021-fb8c91b157
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/977
       type: fast-track


### PR DESCRIPTION
Sync manifest-lock.overrides too