### PR TITLE
[release-4.9] Update fedora-coreos-config to latest stable Nov 9

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -14,21 +14,21 @@ packages:
     metadata:
       reason: https://bugzilla.redhat.com/show_bug.cgi?id=1980693
       type: pin
-  coreos-installer:
-    evr: 0.10.1-1.fc34
+  dracut:
+    evr: 055-6.fc34
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-3d52eb54ca
-      reason: https://github.com/coreos/coreos-installer/security/advisories/GHSA-3r3g-g73x-g593
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-854826abc1
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/943
       type: fast-track
-  coreos-installer-bootinfra:
-    evr: 0.10.1-1.fc34
+  dracut-network:
+    evr: 055-6.fc34
     metadata:
-      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-3d52eb54ca
-      reason: https://github.com/coreos/coreos-installer/security/advisories/GHSA-3r3g-g73x-g593
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-854826abc1
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/943
       type: fast-track
-  ignition:
-    evr: 2.12.0-3.fc34
+  dracut-squash:
+    evr: 055-6.fc34
     metadata:
-      bodhi:  https://bodhi.fedoraproject.org/updates/FEDORA-2021-fb8c91b157
-      reason: https://github.com/coreos/fedora-coreos-tracker/issues/977
+      bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-854826abc1
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/943
       type: fast-track


### PR DESCRIPTION
Sync manifest-lock overrides. This should bring in 1.22.2 kubelet