### PR TITLE
Use MC kernelArguments field instead of `/etc/pivot/kernel-args` file

### DIFF
--- a/bootstrap/overlay/etc/pivot/kernel-args
+++ b/bootstrap/overlay/etc/pivot/kernel-args
@@ -1,2 +1,0 @@
-ADD systemd.unified_cgroup_hierarchy=1
-DELETE mitigations=auto,nosmt

--- a/manifests/99-okd-master-disable-mitigations.yaml
+++ b/manifests/99-okd-master-disable-mitigations.yaml
@@ -12,15 +12,6 @@ spec:
   config:
     ignition:
       version: 3.2.0
-    storage:
-      files:
-        - contents:
-            source: >-
-              data:text/plain;charset=utf-8;base64,REVMRVRFIG1pdGlnYXRpb25zPWF1dG8sbm9zbXQKQUREIHN5c3RlbWQudW5pZmllZF9jZ3JvdXBfaGllcmFyY2h5PTEK
-            verification: {}
-          group: {}
-          mode: 384
-          overwrite: true
-          path: /etc/pivot/kernel-args
-          user:
-            name: root
+  kernelArguments:
+    - mitigations=off
+    - systemd.unified_cgroup_hierarchy=1

--- a/manifests/99-okd-worker-disable-mitigations.yaml
+++ b/manifests/99-okd-worker-disable-mitigations.yaml
@@ -12,15 +12,6 @@ spec:
   config:
     ignition:
       version: 3.2.0
-    storage:
-      files:
-        - contents:
-            source: >-
-              data:text/plain;charset=utf-8;base64,REVMRVRFIG1pdGlnYXRpb25zPWF1dG8sbm9zbXQKQUREIHN5c3RlbWQudW5pZmllZF9jZ3JvdXBfaGllcmFyY2h5PTEK
-            verification: {}
-          group: {}
-          mode: 384
-          overwrite: true
-          path: /etc/pivot/kernel-args
-          user:
-            name: root
+  kernelArguments:
+    - mitigations=off
+    - systemd.unified_cgroup_hierarchy=1


### PR DESCRIPTION
Not sure if this'll work, but I'd like us to move away from the deprecated /etc/pivot/kernal-args file interface for adding kargs.
Ideally, MCO will gain support for kargs in Ignition itself, but it's not there yet: https://issues.redhat.com/browse/MCO-8