### PR TITLE
[release-4.7] Remove .github, dependabot doesn't work for non-default branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "gitsubmodules"
-    directory: "/"
-    target-branch: "release-4.7"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
Remove dependabot config to trigger a new build