### PR TITLE
[release-4.9] kernel arguments: don't track kernel-args

### DIFF
--- a/manifests/99-okd-master-disable-mitigations.yaml
+++ b/manifests/99-okd-master-disable-mitigations.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
   labels:
     machineconfiguration.openshift.io/role: master
   name: 99-okd-master-disable-mitigations

--- a/manifests/99-okd-master-disable-mitigations.yaml
+++ b/manifests/99-okd-master-disable-mitigations.yaml
@@ -13,15 +13,5 @@ spec:
   config:
     ignition:
       version: 3.2.0
-    storage:
-      files:
-        - contents:
-            source: >-
-              data:text/plain;charset=utf-8;base64,REVMRVRFIG1pdGlnYXRpb25zPWF1dG8sbm9zbXQK
-            verification: {}
-          group: {}
-          mode: 384
-          overwrite: true
-          path: /etc/pivot/kernel-args
-          user:
-            name: root
+  kernelArguments:
+    - mitigations=off

--- a/manifests/99-okd-worker-disable-mitigations.yaml
+++ b/manifests/99-okd-worker-disable-mitigations.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
   labels:
     machineconfiguration.openshift.io/role: worker
   name: 99-okd-worker-disable-mitigations

--- a/manifests/99-okd-worker-disable-mitigations.yaml
+++ b/manifests/99-okd-worker-disable-mitigations.yaml
@@ -13,15 +13,5 @@ spec:
   config:
     ignition:
       version: 3.2.0
-    storage:
-      files:
-        - contents:
-            source: >-
-              data:text/plain;charset=utf-8;base64,REVMRVRFIG1pdGlnYXRpb25zPWF1dG8sbm9zbXQK
-            verification: {}
-          group: {}
-          mode: 384
-          overwrite: true
-          path: /etc/pivot/kernel-args
-          user:
-            name: root
+  kernelArguments:
+    - mitigations=off


### PR DESCRIPTION
CVO should not be tracking this file, so that users could modify it enabling cgroupsv2 mode when required