### PR TITLE
crio.repo: switch to cri-o 1.23

### DIFF
--- a/crio.repo
+++ b/crio.repo
@@ -1,9 +1,9 @@
 [crio]
 name=crio
 type=rpm
-baseurl=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.22/Fedora_34/
+baseurl=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.23/Fedora_34/
 gpgcheck=1
-gpgkey=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.22/Fedora_34/repodata/repomd.xml.key
+gpgkey=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.23/Fedora_34/repodata/repomd.xml.key
 enabled=1
 [cri-tools]
 name=cri-tools


### PR DESCRIPTION
Use https://build.opensuse.org/project/show/devel:kubic:libcontainers:stable:cri-o:1.23 as source of cri-o packages

Alternative to #274, which we won't have to pass through Bodhi process