### PR TITLE
[release-4.9] Dockerfile.template: bump machine-os version

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,5 +6,5 @@ COPY manifests/ /manifests/
 COPY bootstrap/ /bootstrap/
 LABEL io.openshift.release.operator=true \
       io.openshift.build.version-display-names="machine-os=Fedora CoreOS" \
-      io.openshift.build.versions="machine-os=49.34.4"
+      io.openshift.build.versions="machine-os=49.34.5"
 ENTRYPOINT ["/noentry"]


### PR DESCRIPTION
This should pull in updated polkit