### PR TITLE
[release-4.9] Dockerfile.template: bump machine-os version

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,5 +6,5 @@ COPY manifests/ /manifests/
 COPY bootstrap/ /bootstrap/
 LABEL io.openshift.release.operator=true \
       io.openshift.build.version-display-names="machine-os=Fedora CoreOS" \
-      io.openshift.build.versions="machine-os=49.34.4"
+      io.openshift.build.versions="machine-os=49.34.5"
 ENTRYPOINT ["/noentry"]

--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -32,3 +32,13 @@ packages:
       bodhi: https://bodhi.fedoraproject.org/updates/FEDORA-2021-854826abc1
       reason: https://github.com/coreos/fedora-coreos-tracker/issues/943
       type: fast-track
+  polkit:
+    evr: 0.117-3.fc34.2
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2025869
+      type: pin
+  polkit-libs:
+    evr: 0.117-3.fc34.2
+    metadata:
+      reason: https://bugzilla.redhat.com/show_bug.cgi?id=2025869
+      type: pin


### PR DESCRIPTION
This should pull in `polkit-0.117-3.fc34.2.x86_64` for https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-4034