### PR TITLE
dependabot: create new PRs weekly

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
Daily PRs to bump FCOS in master branch are too frequent, resetting this to weekly