### PR TITLE
[release-4.10] Pin kernel to 5.15.18-200.fc35

### DIFF
--- a/manifest-lock.overrides.yaml
+++ b/manifest-lock.overrides.yaml
@@ -1,1 +1,16 @@
-packages: {}
+packages:
+  kernel:
+    evr: 5.15.18-200.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
+      type: pin
+  kernel-core:
+    evr: 5.15.18-200.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
+      type: pin
+  kernel-modules:
+    evr: 5.15.18-200.fc35
+    metadata:
+      reason: https://github.com/coreos/fedora-coreos-tracker/issues/1066
+      type: pin

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -14,6 +14,7 @@ ref: fedora/${basearch}/coreos/okd
 repos:
   - fedora
   - fedora-updates
+  - updates-archive
   - crio
   - cri-tools
   - okd-rpms


### PR DESCRIPTION
See https://github.com/coreos/fedora-coreos-tracker/issues/1066