### PR TITLE
[release-4.10] Bump machine-os version

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,5 +6,5 @@ COPY manifests/ /manifests/
 COPY bootstrap/ /bootstrap/
 LABEL io.openshift.release.operator=true \
       io.openshift.build.version-display-names="machine-os=Fedora CoreOS" \
-      io.openshift.build.versions="machine-os=410.35.2"
+      io.openshift.build.versions="machine-os=410.35.3"
 ENTRYPOINT ["/noentry"]


### PR DESCRIPTION
Pull in fresh Fedora/CRI-O updates.

Fixes https://github.com/openshift/okd/issues/1156