### PR TITLE
manifests: add support secret

### DIFF
--- a/manifests/99-sca-disable.yaml
+++ b/manifests/99-sca-disable.yaml
@@ -1,0 +1,8 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: support
+  namespace: openshift-config
+stringData:
+  scaPullDisabled: true
+type: Opaque


### PR DESCRIPTION
This disables SCA setting for Insights Operator to prevent SCA alert.

Fixes https://github.com/openshift/okd/issues/1135