### PR TITLE
[release-4.10] fix-resolv-conf-search.service: run after NM

### DIFF
--- a/overlay.d/99okd/usr/lib/systemd/system/fix-resolv-conf-search.service
+++ b/overlay.d/99okd/usr/lib/systemd/system/fix-resolv-conf-search.service
@@ -3,6 +3,7 @@ Description=Remove search . from /etc/resolv.conf
 DefaultDependencies=no
 Requires=systemd-resolved.service
 After=systemd-resolved.service
+After=NetworkManager.service
 BindsTo=systemd-resolved.service
 
 [Service]


### PR DESCRIPTION
Ensure that resolv.conf search domain patching runs after NM has built a new resolv.conf. This should prevent coredns from picking up stub resolver.

Cherry-pick of #323 on release-4.10 branch
Fixes https://github.com/openshift/okd/issues/978