### PR TITLE
OKD overlay: fix openvswitch permissions

### DIFF
--- a/overlay.d/99okd/etc/systemd/ovsdb-server.service.d/99-okd-permission-fix.conf
+++ b/overlay.d/99okd/etc/systemd/ovsdb-server.service.d/99-okd-permission-fix.conf
@@ -1,0 +1,5 @@
+[Service]
+Restart=always
+ExecStartPre=-/bin/sh -c '/usr/bin/chown -R ${OVS_USER_ID} /var/lib/openvswitch'
+ExecStartPre=-/bin/sh -c '/usr/bin/chown -R ${OVS_USER_ID} /etc/openvswitch'
+ExecStartPre=-/bin/sh -c '/usr/bin/chown -R ${OVS_USER_ID} /run/openvswitch'


### PR DESCRIPTION
Make sure openvswitch configs and run dirs are owned by OVS user.

Hopefully that fixes https://github.com/openshift/okd/issues/1168.

Mirrored as `quay.io/vrutkovs/okd-release:4.11-apr-2-pr331`

Latest stable upgrade jobs:
* [aws](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws-modern/1510195747880964096)
* [gcp](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-gcp-modern/1510195756512841728)