### PR TITLE
okd overlay: fix openvswitch permissions

### DIFF
--- a/overlay.d/99okd/usr/lib/systemd/system/ovsdb-server.service.d/99-okd-permission-fix.conf
+++ b/overlay.d/99okd/usr/lib/systemd/system/ovsdb-server.service.d/99-okd-permission-fix.conf
@@ -1,0 +1,5 @@
+[Service]
+Restart=always
+ExecStartPre=-/bin/sh -c '/usr/bin/chown -R ${OVS_USER_ID} /var/lib/openvswitch'
+ExecStartPre=-/bin/sh -c '/usr/bin/chown -R ${OVS_USER_ID} /etc/openvswitch'
+ExecStartPre=-/bin/sh -c '/usr/bin/chown -R ${OVS_USER_ID} /run/openvswitch'


### PR DESCRIPTION
Make sure openvswitch configs and run dirs are owned by OVS user. We can't place the dropin in `/etc/systemd` as [it is being cleaned up in post-process](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/manifests/ignition-and-ostree.yaml#L45)

Hopefully that fixes https://github.com/openshift/okd/issues/1168.

Mirrored as `quay.io/vrutkovs/okd-release:4.11-apr-4-pr334-v2`

Upgrade jobs:
* [aws](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws-modern/1511080234059829248)
* [gcp](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws-modern/1511084057058873344)
* [aws no disruption tests](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws-modern/1511228111021150208)