### PR TITLE
[release-4.10] okd overlay: fix openvswitch permissions

### DIFF
--- a/overlay.d/99okd/usr/lib/systemd/system/ovsdb-server.service.d/99-okd-permission-fix.conf
+++ b/overlay.d/99okd/usr/lib/systemd/system/ovsdb-server.service.d/99-okd-permission-fix.conf
@@ -1,0 +1,5 @@
+[Service]
+Restart=always
+ExecStartPre=-/bin/sh -c '/usr/bin/chown -R ${OVS_USER_ID} /var/lib/openvswitch'
+ExecStartPre=-/bin/sh -c '/usr/bin/chown -R ${OVS_USER_ID} /etc/openvswitch'
+ExecStartPre=-/bin/sh -c '/usr/bin/chown -R ${OVS_USER_ID} /run/openvswitch'


### PR DESCRIPTION
Make sure openvswitch configs and run dirs are owned by OVS user.

Cherry-pick of https://github.com/openshift/okd-machine-os/pull/334 on release-4.10