### PR TITLE
[release-4.10] Configure DHCP client identifier via NM

### DIFF
--- a/overlay.d/99okd/etc/dhclient/dhclient.conf
+++ b/overlay.d/99okd/etc/dhclient/dhclient.conf
@@ -1,1 +1,0 @@
-send dhcp-client-identifier = hardware;

--- a/overlay.d/99okd/usr/lib/NetworkManager/conf.d/20-dhcp-client-id-mac.conf
+++ b/overlay.d/99okd/usr/lib/NetworkManager/conf.d/20-dhcp-client-id-mac.conf
@@ -1,0 +1,2 @@
+[connection-dhcp-client-id-mac]
+ipv4.dhcp-client-id=mac


### PR DESCRIPTION
This change removes the `/etc/dhclient/dhclient.conf` file that
has been unused since the deprecation of dhclient in Fedora from
the `99okd` overlay, and replaces it with a NetworkManager config
snippet for configuring NM's DHCP client to use
`ipv4.dhcp-client-id=mac`.

See also:
- https://fedoraproject.org/wiki/Changes/dhclient_deprecation
- https://bugzilla.redhat.com/show_bug.cgi?id=1204226

Cherry-pick of #338 on release-4.10