### PR TITLE
[release-4.10] Seperate the two fixes for the 'dot' in /etc/resolv.conf and the coredns

### DIFF
--- a/overlay.d/99okd/usr/lib/systemd/system-preset/00-okd.preset
+++ b/overlay.d/99okd/usr/lib/systemd/system-preset/00-okd.preset
@@ -1,7 +1,9 @@
 # Fetch GCP hostnames via afterburn
 enable gcp-hostnames.service
 # Remove "search ." from /run/systemd/resolve/resolv.conf if it exists
-enable fix-resolv-conf-search.service
+enable fix-resolv-conf-dot.service
+# Fix resolve.conf issue with coreDNS 
+enable fix-resolv-conf-coredns.service
 # Skip cgroups warning
 disable coreos-check-cgroups.service
 # Enable ovirt service

--- a/overlay.d/99okd/usr/lib/systemd/system/fix-resolv-conf-coredns.service
+++ b/overlay.d/99okd/usr/lib/systemd/system/fix-resolv-conf-coredns.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Fix NM resolv.conf issues with coreDNS
+DefaultDependencies=no
+Requires=systemd-resolved.service
+After=systemd-resolved.service fix-resolv-conf-dot.service network-online.target
+Before=crio.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/cp /run/systemd/resolve/resolv.conf /var/run/NetworkManager/resolv.conf
+
+[Install]
+WantedBy=multi-user.target

--- a/overlay.d/99okd/usr/lib/systemd/system/fix-resolv-conf-dot.service
+++ b/overlay.d/99okd/usr/lib/systemd/system/fix-resolv-conf-dot.service
@@ -2,15 +2,13 @@
 Description=Remove search . from /etc/resolv.conf
 DefaultDependencies=no
 Requires=systemd-resolved.service
-After=systemd-resolved.service
-After=NetworkManager.service
+After=systemd-resolved.service network-online.target
+Before=crio.service
 BindsTo=systemd-resolved.service
 
 [Service]
 Type=oneshot
-ExecStartPre=/usr/bin/sleep 5
 ExecStart=/usr/bin/sed -i -e "s/^search .$//" /run/systemd/resolve/resolv.conf
-ExecStart=/usr/bin/cp /run/systemd/resolve/resolv.conf /var/run/NetworkManager/resolv.conf
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
/etc/resolv.conf copy.

Both are dependent on systemd-resolved but need to be run after
network-online.target to ensure systemd-resolved and NetworkManager have
finished initializing.

make fix-resolv-conf-coredns.service dependent on fix-resolv-conf-dot.service in case there is a dot.

cherry-pick of https://github.com/openshift/okd-machine-os/pull/349 on release-4.10