### PR TITLE
WIP manifests: use external cloud providers and CSI by default

### DIFF
--- a/manifests/99-okd-featureset.yaml
+++ b/manifests/99-okd-featureset.yaml
@@ -1,0 +1,19 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+  name: cluster
+spec:
+  customNoUpgrade:
+    enabled:
+    - ExternalCloudProvider
+    - CSIMigrationAWS
+    - CSIMigrationOpenStack
+    - CSIMigrationAzureDisk
+    - CSIDriverAzureDisk
+    - CSIDriverVSphere
+    - CSIMigrationvSphere
+  featureSet: CustomNoUpgrade


### PR DESCRIPTION
Use two features not yet enabled in OCP - CSI migration in the clouds and external cloud providers. Note that it cannot be reverted and may impact upgrades