### PR TITLE
Dockerfile: make sure gcp-routes and gcp-hostname services are enabled

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -17,6 +17,7 @@ RUN cat /etc/os-release \
     && rpm-ostree --version \
     && ostree --version \
     && cp -irvf overlay.d/*/* / \
+    && systemctl enable gcp-routes gcp-hostname \
     && cp -irvf bootstrap / \
     && cp -irvf manifests / \
     && rpm-ostree install \


### PR DESCRIPTION
These are required for GCP machines to be able to contact each other