### PR TITLE
mitigations: set - spectre_v2=off

### DIFF
--- a/manifests/99-okd-master-disable-mitigations.yaml
+++ b/manifests/99-okd-master-disable-mitigations.yaml
@@ -16,3 +16,4 @@ spec:
   kernelArguments:
     - mitigations=off
     - intel_pstate=disable
+    - spectre_v2=off

--- a/manifests/99-okd-worker-disable-mitigations.yaml
+++ b/manifests/99-okd-worker-disable-mitigations.yaml
@@ -16,3 +16,4 @@ spec:
   kernelArguments:
     - mitigations=off
     - intel_pstate=disable
+    - spectre_v2=off


### PR DESCRIPTION
This should additionally disable retbleed mitigation, known to significantly
 decrease performance in kernel 5.19 (at least in vSphere)

https://lore.kernel.org/lkml/PH0PR05MB8448A203A909959FAC754B7AAF439@PH0PR05MB8448.namprd05.prod.outlook.com/