### PR TITLE
OKD-63: Use CoreOS Continuous copr packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN cat /etc/os-release \
     && systemctl enable gcp-routes gcp-hostname \
     && cp -irvf bootstrap / \
     && cp -irvf manifests / \
-    && cp -ivf okd-copr.repo /etc/yum.repos.d/ \
+    && cp -ivf *.repo /etc/yum.repos.d/ \
     && rpm-ostree install \
         NetworkManager-ovs \
         open-vm-tools \
@@ -22,10 +22,13 @@ RUN cat /etc/os-release \
         cri-tools \
         /tmp/rpms/openshift-clients-[0-9]*.rpm \
         /tmp/rpms/openshift-hyperkube-*.rpm \
+    && rpm-ostree override replace \
+         --experimental --freeze \
+         --from repo=coreos-continuous \
+         rpm-ostree rpm-ostree-libs \
     && rpm-ostree cleanup -m \
     && sed -i 's/^enabled=1/enabled=0/g' /etc/yum.repos.d/*.repo \
-    && rm -rf /go /tmp/rpms /var/cache \
-    && ostree container commit
+    && rm -rf /go /tmp/rpms /var/cache
 LABEL io.openshift.release.operator=true \
       io.openshift.build.version-display-names="machine-os=Fedora CoreOS" \
       io.openshift.build.versions="machine-os=${FEDORA_COREOS_VERSION}"

--- a/coreos-continuous.repo
+++ b/coreos-continuous.repo
@@ -1,0 +1,10 @@
+[coreos-continuous]
+name=Copr repo for continuous owned by @CoreOS
+baseurl=https://download.copr.fedorainfracloud.org/results/@CoreOS/continuous/fedora-$releasever-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/@CoreOS/continuous/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1


### PR DESCRIPTION
Fresh `rpm-ostree` from this COPR should fix https://issues.redhat.com/browse/OKD-63