### PR TITLE
build: Drop `ENTRYPOINT` override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,3 @@ RUN cat /etc/os-release \
 LABEL io.openshift.release.operator=true \
       io.openshift.build.version-display-names="machine-os=Fedora CoreOS" \
       io.openshift.build.versions="machine-os=${FEDORA_COREOS_VERSION}"
-ENTRYPOINT ["/noentry"]


### PR DESCRIPTION
This is no longer necessary with the new-format base image model and in fact is an anti-pattern because it inhibits running the container directly, which is a valid use case:

```
$ podman run --rm -ti registry.ci.openshift.org/origin/4.12:fedora-coreos
```

should give me a bash shell, not an error.