### PR TITLE
Dockerfile: remove kernel pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN cat /etc/os-release \
         /tmp/rpms/openshift-clients-[0-9]*.rpm \
         /tmp/rpms/openshift-hyperkube-*.rpm \
     && rpm-ostree cliwrap install-to-root / \
-    && rpm-ostree override replace https://koji.fedoraproject.org/koji/buildinfo?buildID=1969515 \
     && rpm-ostree ex rebuild \
     && rpm-ostree cleanup -m \
     && ln -s /usr/sbin/ovs-vswitchd.dpdk /usr/sbin/ovs-vswitchd \


### PR DESCRIPTION
Due to [OKD-62](https://issues.redhat.com//browse/OKD-62) the kernel is pinned to 5.18. This commits removes pin to use latest available