### PR TITLE
overlay: add 05rhcos

### DIFF
--- a/overlay.d/05rhcos
+++ b/overlay.d/05rhcos
@@ -1,0 +1,1 @@
+../openshift-os/overlay.d/05rhcos/


### PR DESCRIPTION
This should apply RHCOS changes, selinux policy upgrade in particular.
Unlike [4.11 cherrypick](https://github.com/openshift/okd-machine-os/pull/451) we're applying the whole overlay - there's plenty of time in the cycle to work out the quirks

Ref: https://github.com/okd-project/okd/issues/1317