### PR TITLE
Dockerfile.ci: fetch version from next-devel

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 # Label okd-machine-os image with Fedora CoreOS version extracted from /etc/release
-FROM quay.io/coreos-assembler/fcos:testing-devel
+FROM quay.io/coreos-assembler/fcos:next-devel
 COPY . /go/src/github.com/openshift/okd-machine-os
 WORKDIR /go/src/github.com/openshift/okd-machine-os
 RUN source /etc/os-release \


### PR DESCRIPTION
Update Dockerfile.ci to use the same base image as Dockerfile so that FEDORA_COREOS_VERSION would be correct