### PR TITLE
WIP pre-pivot: use live-apply in bootstrap node if possible

### DIFF
--- a/bootstrap/pre-pivot.sh
+++ b/bootstrap/pre-pivot.sh
@@ -13,4 +13,4 @@ rpm-ostree rebase --experimental "ostree-unverified-registry:${MACHINE_CONFIG_OS
 # Remove mitigations kargs
 rpm-ostree kargs --delete mitigations=auto,nosmt
 touch /opt/openshift/.pivot-done
-systemctl reboot
+rpm-ostree ex apply-live || systemctl reboot


### PR DESCRIPTION
Instead of rebooting the machine we could apply the pending deployment now. If that fails a proper reboot is initiated

This should improve the bootstrap time, but that would not apply mitigation kargs, so I'm not sure if its worth it.

TODO:
* [ ] Find a way to test this with `apply-live` path