### PR TITLE
Temporary fix to take the rpms in the correct folder from both prow and the okd-payload-pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG FEDORA_COREOS_VERSION=412.37.0
 
 WORKDIR /go/src/github.com/openshift/okd-machine-os
 COPY . .
-COPY --from=artifacts /srv/repo/*.rpm /tmp/rpms/
+COPY --from=artifacts /srv/repo/ /tmp/rpms/
 ADD overrides.yaml /etc/rpm-ostree/origin.d/overrides.yaml
 RUN cat /etc/os-release \
     && rpm-ostree --version \
@@ -21,15 +21,17 @@ RUN cat /etc/os-release \
         qemu-guest-agent \
         cri-o \
         cri-tools \
-        /tmp/rpms/openshift-clients-[0-9]*.rpm \
-        /tmp/rpms/openshift-hyperkube-*.rpm \
+        # TODO: temporary fix in the next two rows: see okd-project/okd-payload-pipeline#15
+        /tmp/rpms/$([ -d /tmp/rpms/$(uname -m) ] && echo $(uname -m)/)openshift-clients-[0-9]*.rpm \
+        /tmp/rpms/$([ -d /tmp/rpms/$(uname -m) ] && echo $(uname -m)/)openshift-hyperkube-*.rpm \
     && rpm-ostree cliwrap install-to-root / \
     && rpm-ostree override replace https://koji.fedoraproject.org/koji/buildinfo?buildID=1969515 \
     && rpm-ostree ex rebuild \
     && rpm-ostree cleanup -m \
     && ln -s /usr/sbin/ovs-vswitchd.dpdk /usr/sbin/ovs-vswitchd \
-    && rm -rf /go /var/lib/unbound \
+    && rm -rf /go /var/lib/unbound /tmp/rpms \
     && ostree container commit
+
 LABEL io.openshift.release.operator=true \
       io.openshift.build.version-display-names="machine-os=Fedora CoreOS" \
       io.openshift.build.versions="machine-os=${FEDORA_COREOS_VERSION}"


### PR DESCRIPTION
This PR refers okd-project/okd-payload-pipeline#15

It should be considered a temporary fix to remove when the solutions for the hyperkube, cli and artifacts builds in both okd-payload-pipeline and the current ci converge.

Let's also consider the removal of the /tmp/rpms content. If we want to keep it, I can split the commit or the PR

/cc @vrutkovs @LorbusChris 