### PR TITLE
[release-4.11] Revert "manifest: Use cri-o module from Fedora"

### DIFF
--- a/crio.repo
+++ b/crio.repo
@@ -1,0 +1,14 @@
+[crio]
+name=crio
+type=rpm
+baseurl=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.24/Fedora_36/
+gpgcheck=1
+gpgkey=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.24/Fedora_36/repodata/repomd.xml.key
+enabled=1
+[cri-tools]
+name=cri-tools
+type=rpm-md
+baseurl=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Fedora_36/
+gpgcheck=1
+gpgkey=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Fedora_36/repodata/repomd.xml.key
+enabled=1

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -14,8 +14,8 @@ ref: fedora/${basearch}/coreos/okd
 repos:
   - fedora
   - fedora-updates
-  - fedora-modular
-  - fedora-updates-modular
+  - crio
+  - cri-tools
   - okd-rpms
   - updates-archive
 
@@ -30,13 +30,6 @@ packages:
   - fedora-repos-archive
   # User metrics
   - fedora-coreos-pinger
-
-modules:
-  enable:
-    - cri-o:1.24
-  install:
-    # cri-o and cri-tools
-    - cri-o:1.24/default
 
 # We include hours/minutes to avoid version number reuse
 automatic-version-prefix: "411.36.<date:%Y%m%d%H%M>"

--- a/okd-packages.yaml
+++ b/okd-packages.yaml
@@ -4,5 +4,7 @@ packages:
 - qemu-guest-agent
 - glusterfs
 - glusterfs-fuse
+- crio
+- cri-tools
 - openshift-hyperkube
 - openshift-clients


### PR DESCRIPTION
This reverts commit 67025f3d40d34fe171611fb23fad054e049f9cf7.

Reverting #249 as now cri-o module lags behind in F36 and it affects OKD 4.11, as predicted in https://github.com/openshift/okd-machine-os/pull/249#issuecomment-1149794989