### PR TITLE
OKD-90: Add okd-rpms in the payload

### DIFF
--- a/Dockerfile.rpms
+++ b/Dockerfile.rpms
@@ -6,3 +6,8 @@ COPY okd-copr.repo /etc/yum.repos.d
 RUN microdnf download cri-o cri-tools --archlist=$(arch) \
     && rm -rf /var/cache
 COPY --from=artifacts /srv/repo/*.rpm /rpms/
+LABEL io.k8s.display-name="OKD RPMs" \
+      io.k8s.description="This image contains necessary RPMs to start kubelet with cri-o" \
+      io.openshift.tags="openshift" \
+      # Not an operator, but required to be added to the payload
+      io.openshift.release.operator=true


### PR DESCRIPTION
Create image references file, so that okd-rpms image would be included in the resulting payload.
Later `okd-rpms` image would be used by Assisted Installer to automatically overlay crio and kubelet on FCOS so that discovery agent could start bootstrap.service