### PR TITLE
OKD-98: okd-rpms: copy manifests

### DIFF
--- a/Dockerfile.rpms
+++ b/Dockerfile.rpms
@@ -6,6 +6,7 @@ COPY okd-copr.repo /etc/yum.repos.d
 RUN microdnf download cri-o cri-tools --archlist=$(arch) \
     && rm -rf /var/cache
 COPY --from=artifacts /srv/repo/*.rpm /rpms/
+COPY ./bootstrap/manifests /manifests/
 LABEL io.k8s.display-name="OKD RPMs" \
       io.k8s.description="This image contains necessary RPMs to start kubelet with cri-o" \
       io.openshift.tags="openshift" \


### PR DESCRIPTION
okd-rpms image is used by Assisted Installer, which also needs to copy
bootstrap manifests on the node so that MCO would be able to assemble
initial MC