### PR TITLE
pre-pivot: fetch "fedora-coreos" image

### DIFF
--- a/bootstrap/pre-pivot.sh
+++ b/bootstrap/pre-pivot.sh
@@ -9,9 +9,9 @@ cp overlay/etc / -rvf
 cp manifests/* /opt/openshift/openshift/ -rvf
 
 # Pivot to new os content
-MACHINE_CONFIG_OSCONTENT=$(image_for machine-os-content)
+MACHINE_OS_IMAGE=$(image_for fedora-coreos)
 stat /etc/containers/registries.conf
-rpm-ostree rebase --experimental "ostree-unverified-registry:${MACHINE_CONFIG_OSCONTENT}"
+rpm-ostree rebase --experimental "ostree-unverified-registry:${MACHINE_OS_IMAGE}"
 # Remove mitigations kargs
 rpm-ostree kargs --delete mitigations=auto,nosmt
 touch /opt/openshift/.pivot-done


### PR DESCRIPTION
This updates OKD OS image name to use "fedora-coreos" instead of deprecated "machine-os-content"