### PR TITLE
pre-pivot: change registries.conf permission

### DIFF
--- a/bootstrap/pre-pivot.sh
+++ b/bootstrap/pre-pivot.sh
@@ -10,8 +10,10 @@ cp manifests/* /opt/openshift/openshift/ -rvf
 
 # Pivot to new os content
 MACHINE_OS_IMAGE=$(image_for fedora-coreos)
-stat /etc/containers/registries.conf
+# Make sure registries.conf is readable by rpm-ostree
+chmod 0644 /etc/containers/registries.conf
 rpm-ostree rebase --experimental "ostree-unverified-registry:${MACHINE_OS_IMAGE}"
+
 # Remove mitigations kargs
 rpm-ostree kargs --delete mitigations=auto,nosmt
 touch /opt/openshift/.pivot-done


### PR DESCRIPTION
This makes sure rpm-ostreed can read registries.conf file so that rpm-ostree rebase via OCI containers