### PR TITLE
[release 4.12] pre-pivot: change registries.conf permission

### DIFF
--- a/bootstrap/pre-pivot.sh
+++ b/bootstrap/pre-pivot.sh
@@ -9,9 +9,11 @@ cp overlay/etc / -rvf
 cp manifests/* /opt/openshift/openshift/ -rvf
 
 # Pivot to new os content
-MACHINE_CONFIG_OSCONTENT=$(image_for machine-os-content)
-stat /etc/containers/registries.conf
-rpm-ostree rebase --experimental "ostree-unverified-registry:${MACHINE_CONFIG_OSCONTENT}"
+MACHINE_OS_IMAGE=$(image_for fedora-coreos)
+# Make sure registries.conf is readable by rpm-ostree
+chmod 0644 /etc/containers/registries.conf
+rpm-ostree rebase --experimental "ostree-unverified-registry:${MACHINE_OS_IMAGE}"
+
 # Remove mitigations kargs
 rpm-ostree kargs --delete mitigations=auto,nosmt
 touch /opt/openshift/.pivot-done


### PR DESCRIPTION
This makes sure rpm-ostreed can read registries.conf file so that rpm-ostree rebase via OCI containers 