### PR TITLE
Base the 4.12 okd's fedora-coreos and machine-os-content images from fedora-coreos:stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.ci.openshift.org/origin/4.12:artifacts as artifacts
 
-FROM quay.io/fedora/fedora-coreos:next-devel
+FROM quay.io/fedora/fedora-coreos:stable
 ARG FEDORA_COREOS_VERSION=412.37.0
 
 WORKDIR /go/src/github.com/openshift/okd-machine-os

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 # Label okd-machine-os image with Fedora CoreOS version extracted from /etc/release
-FROM quay.io/fedora/fedora-coreos:next-devel
+FROM quay.io/fedora/fedora-coreos:stable
 COPY . /go/src/github.com/openshift/okd-machine-os
 WORKDIR /go/src/github.com/openshift/okd-machine-os
 RUN source /etc/os-release \


### PR DESCRIPTION
This PR will let the fedora-coreos and machine-os-content images built for OKD 4.12 base from quay.io/fedora/fedora-coreos:stable.

/cc @vrutkovs 