### PR TITLE
[release-4.12] Dockerfile: remove rpm-ostree override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ ARG FEDORA_COREOS_VERSION=412.37.0
 WORKDIR /go/src/github.com/openshift/okd-machine-os
 COPY . .
 COPY --from=artifacts /srv/repo/ /tmp/rpms/
-ADD overrides.yaml /etc/rpm-ostree/origin.d/overrides.yaml
 RUN cat /etc/os-release \
     && rpm-ostree --version \
     && ostree --version \

--- a/overrides.yaml
+++ b/overrides.yaml
@@ -1,7 +1,0 @@
-ex-override-replace:
-  - from:
-      repo: coreos-continuous
-    packages:
-      # Pull the latest fix for https://issues.redhat.com/browse/OKD-63
-      - rpm-ostree
-      - rpm-ostree-libs


### PR DESCRIPTION
OKD 4.12 is now stable and should not override rpm-ostree with testing version from COPR