### PR TITLE
Dockerfile.rpms: use stable CRIO releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.ci.openshift.org/origin/4.12:artifacts as artifacts
 
-FROM quay.io/fedora/fedora-coreos:stable
+FROM registry.ci.openshift.org/origin/4.12:machine-os-content
 ARG FEDORA_COREOS_VERSION=412.37.0
 
 WORKDIR /go/src/github.com/openshift/okd-machine-os
@@ -20,8 +20,6 @@ RUN cat /etc/os-release \
         qemu-guest-agent \
         cri-o \
         cri-tools \
-        /tmp/rpms/openshift-clients-[0-9]*.rpm \
-        /tmp/rpms/openshift-hyperkube-*.rpm \
     && rpm-ostree cleanup -m \
     && ln -s /usr/sbin/ovs-vswitchd.dpdk /usr/sbin/ovs-vswitchd \
     && rm -rf /go /tmp/rpms /var/cache /var/lib/unbound \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN cat /etc/os-release \
         cri-o \
         cri-tools \
     && rpm-ostree cleanup -m \
-    && ln -s /usr/sbin/ovs-vswitchd.dpdk /usr/sbin/ovs-vswitchd \
     && rm -rf /go /tmp/rpms /var/cache /var/lib/unbound \
     && ostree container commit
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN cat /etc/os-release \
     && systemctl enable gcp-routes gcp-hostname \
     && cp -irvf bootstrap / \
     && cp -irvf manifests / \
-    && cp -ivf okd-copr.repo /etc/yum.repos.d/ \
+    && cp -ivf crio.repo /etc/yum.repos.d/ \
     && rpm-ostree install \
         NetworkManager-ovs \
         open-vm-tools \

--- a/Dockerfile.rpms
+++ b/Dockerfile.rpms
@@ -2,7 +2,7 @@ FROM registry.ci.openshift.org/origin/4.12:artifacts as artifacts
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /rpms
-COPY okd-copr.repo /etc/yum.repos.d
+COPY crio.repo /etc/yum.repos.d
 RUN microdnf download cri-o cri-tools --archlist=$(arch) \
     && rm -rf /var/cache
 COPY --from=artifacts /srv/repo/*.rpm /rpms/

--- a/crio.repo
+++ b/crio.repo
@@ -1,0 +1,16 @@
+[cri-o_1.25]
+name=devel:kubic:libcontainers:stable:cri-o:1.25 (Fedora_37)
+type=rpm-md
+baseurl=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.25/Fedora_37/
+gpgcheck=1
+gpgkey=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.25/Fedora_37/repodata/repomd.xml.key
+enabled=1
+
+[cri-tools]
+name=Stable Releases of Upstream github.com/containers packages (Fedora_37)
+type=rpm-md
+baseurl=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Fedora_37/
+gpgcheck=1
+gpgkey=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Fedora_37/repodata/repomd.xml.key
+enabled=1
+

--- a/okd-copr.repo
+++ b/okd-copr.repo
@@ -1,8 +1,0 @@
-[okd-copr]
-name=Copr repo for OKD
-baseurl=https://download.copr.fedorainfracloud.org/results/@OKD/okd/fedora-36-$basearch/
-gpgcheck=1
-gpgkey=https://download.copr.fedorainfracloud.org/results/@OKD/okd/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1


### PR DESCRIPTION
Use official CRI-O packages from OBS in OKD 4.12 