### PR TITLE
okd-copr: use F37 packages

### DIFF
--- a/okd-copr.repo
+++ b/okd-copr.repo
@@ -1,6 +1,6 @@
 [okd-copr]
 name=Copr repo for OKD
-baseurl=https://download.copr.fedorainfracloud.org/results/@OKD/okd/fedora-36-$basearch/
+baseurl=https://download.copr.fedorainfracloud.org/results/@OKD/okd/fedora-37-$basearch/
 gpgcheck=1
 gpgkey=https://download.copr.fedorainfracloud.org/results/@OKD/okd/pubkey.gpg
 repo_gpgcheck=0


### PR DESCRIPTION
This fixes Assisted Installer overlay hack:
```
Feb 02 10:29:22 okd-master-0 okd-binaries.sh[1593]: warning: /tmp/rpms/cri-o-1.25.1-None.fc36.x86_64.rpm: Header V3 RSA/SHA256 Signature, key ID f4c5461c: NOKEY
Feb 02 10:29:22 okd-master-0 okd-binaries.sh[1593]: error: Failed dependencies:
Feb 02 10:29:22 okd-master-0 okd-binaries.sh[1593]:         libc.so.6(GLIBC_2.32)(64bit) is needed by cri-o-0:1.25.1-None.fc36.x86_64                                                         
Feb 02 10:29:22 okd-master-0 okd-binaries.sh[1593]:         libc.so.6(GLIBC_2.33)(64bit) is needed by cri-o-0:1.25.1-None.fc36.x86_64
Feb 02 10:29:22 okd-master-0 okd-binaries.sh[1593]:         libc.so.6(GLIBC_2.34)(64bit) is needed by cri-o-0:1.25.1-None.fc36.x86_64
Feb 02 10:29:22 okd-master-0 okd-binaries.sh[1593]:         libc.so.6(GLIBC_2.32)(64bit) is needed by cri-tools-1.24.2-1.20220811122251151384.master.35.g77d02a03.fc36.x86_64
Feb 02 10:29:22 okd-master-0 okd-binaries.sh[1593]:         libc.so.6(GLIBC_2.34)(64bit) is needed by cri-tools-1.24.2-1.20220811122251151384.master.35.g77d02a03.fc36.x86_64
```