### PR TITLE
overlay: prevent NM from modifying resolv.conf

### DIFF
--- a/overlay.d/99okd/etc/NetworkManager/conf.d/99-okd-dns.conf
+++ b/overlay.d/99okd/etc/NetworkManager/conf.d/99-okd-dns.conf
@@ -1,0 +1,2 @@
+[main]
+dns=none


### PR DESCRIPTION
With on-prem install NM will create /var/run/NetworkManager/resolv.conf
with connection nameservers. This file is used by keepalived and
coredns to determine connection DNS server and avoid hitting CoreDNS.

On recent F37 NM points to systemd-resolved's stub endpoint. This
setting will prevent it from doing that.

This should fix https://github.com/okd-project/okd/issues/1476