### PR TITLE
[release-4.12] Revert "DEBUG: don't pull in fresh FCOS"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,32 @@
 FROM registry.ci.openshift.org/origin/4.12:artifacts as artifacts
 
-FROM registry.ci.openshift.org/origin/4.12:machine-os-content
+FROM quay.io/fedora/fedora-coreos:stable
 ARG FEDORA_COREOS_VERSION=412.37.0
 
 WORKDIR /go/src/github.com/openshift/okd-machine-os
 COPY . .
 COPY --from=artifacts /srv/repo/ /tmp/rpms/
 RUN cat /etc/os-release \
-  && rpm-ostree --version \
-  && ostree --version \
-  && cp -irvf overlay.d/*/* / \
-  && cp -irvf bootstrap / \
-  && cp -irvf manifests / \
-  && cp -ivf crio.repo /etc/yum.repos.d/ \
-  && rpm-ostree install \
-  NetworkManager-ovs \
-  open-vm-tools \
-  qemu-guest-agent \
-  cri-o \
-  cri-tools \
-  netcat \
-  #&& rpm-ostree override replace /tmp/rpms/openshift-hyperkube-*.rpm \
-  && rpm-ostree cleanup -m \
-  && rm -rf /go /tmp/rpms /var/cache /var/lib/unbound \
-  && systemctl preset-all \
-  && ostree container commit
+    && rpm-ostree --version \
+    && ostree --version \
+    && cp -irvf overlay.d/*/* / \
+    && cp -irvf bootstrap / \
+    && cp -irvf manifests / \
+    && cp -ivf crio.repo /etc/yum.repos.d/ \
+    && rpm-ostree install \
+        NetworkManager-ovs \
+        open-vm-tools \
+        qemu-guest-agent \
+        cri-o \
+        cri-tools \
+        netcat \
+        /tmp/rpms/openshift-clients-[0-9]*.rpm \
+        /tmp/rpms/openshift-hyperkube-*.rpm \
+    && rpm-ostree cleanup -m \
+    && ln -s /usr/sbin/ovs-vswitchd.dpdk /usr/sbin/ovs-vswitchd \
+    && rm -rf /go /tmp/rpms /var/cache /var/lib/unbound \
+    && systemctl preset-all \
+    && ostree container commit
 
 LABEL io.openshift.release.operator=true \
   io.openshift.build.version-display-names="machine-os=Fedora CoreOS" \

--- a/crio.repo
+++ b/crio.repo
@@ -1,7 +1,7 @@
 [cri-o_1.25]
 name=devel:kubic:libcontainers:stable:cri-o:1.25 (Fedora_37)
 type=rpm-md
-baseurl=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.25/Fedora_37/
+baseurl=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.25:/1.25.1/Fedora_36/
 gpgcheck=1
 gpgkey=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.25/Fedora_37/repodata/repomd.xml.key
 enabled=1


### PR DESCRIPTION
This reverts commit e83e32a1cb3280265d118377d30bf781fdc6d6e9. Updated FCOS needs to be fetched every time we rebuild this image.

This also pins crio to 1.25.1 as 1.25.2 has a regression (https://issues.redhat.com/browse/OCPBUGS-8093) which fails several storage tests