### PR TITLE
Dockerfile: enable services via systemd presets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN cat /etc/os-release \
     && rpm-ostree --version \
     && ostree --version \
     && cp -irvf overlay.d/*/* / \
-    && systemctl enable gcp-routes gcp-hostname \
+    && systemctl preset-all \
     && cp -irvf bootstrap / \
     && cp -irvf manifests / \
     && cp -ivf *.repo /etc/yum.repos.d/ \


### PR DESCRIPTION
Instead of enabling particular servies we should use systemd presets. This would make sure fix-resolv services are enabled too.