### PR TITLE
[release-4.12] Dockerfile: install netcat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN cat /etc/os-release \
         qemu-guest-agent \
         cri-o \
         cri-tools \
+	netcat \
     && rpm-ostree cleanup -m \
     && rm -rf /go /tmp/rpms /var/cache /var/lib/unbound \
     && ostree container commit


### PR DESCRIPTION
ovs-configuration.service may require it in IPv6 flows

Cherrypick of https://github.com/openshift/okd-machine-os/pull/536 on release-4.12
Ref: https://github.com/okd-project/okd/issues/1523