### PR TITLE
[release-4.12] Dockerfile: enable services via systemd presets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN cat /etc/os-release \
     && rpm-ostree --version \
     && ostree --version \
     && cp -irvf overlay.d/*/* / \
-    && systemctl enable gcp-routes gcp-hostname \
     && cp -irvf bootstrap / \
     && cp -irvf manifests / \
     && cp -ivf crio.repo /etc/yum.repos.d/ \
@@ -23,6 +22,7 @@ RUN cat /etc/os-release \
 	netcat \
     && rpm-ostree cleanup -m \
     && rm -rf /go /tmp/rpms /var/cache /var/lib/unbound \
+    && systemctl preset-all \
     && ostree container commit
 
 LABEL io.openshift.release.operator=true \


### PR DESCRIPTION
Instead of enabling particular servies we should use systemd presets. This would make sure fix-resolv services are enabled too.

Cherry-pick of #535 and #537 on release-4.12