### PR TITLE
Dockerfile: replace existing kubelet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN cat /etc/os-release \
         qemu-guest-agent \
         cri-o \
         cri-tools \
-	netcat \
+        netcat \
+    && rpm-ostree override replace /tmp/rpms/openshift-hyperkube-*.rpm \
     && rpm-ostree cleanup -m \
     && rm -rf /go /tmp/rpms /var/cache /var/lib/unbound \
     && systemctl preset-all \


### PR DESCRIPTION
We're pinned to particular FCOS version, but we still need to make sure newer kubelet is being pulled