### PR TITLE
WIP Use stable FCOS w/ F36 crio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.ci.openshift.org/origin/4.12:artifacts as artifacts
 
-FROM registry.ci.openshift.org/origin/4.12:machine-os-content
+FROM quay.io/fedora/fedora-coreos:stable
 ARG FEDORA_COREOS_VERSION=412.37.0
 
 WORKDIR /go/src/github.com/openshift/okd-machine-os
@@ -20,8 +20,10 @@ RUN cat /etc/os-release \
         cri-o \
         cri-tools \
         netcat \
-    && rpm-ostree override replace /tmp/rpms/openshift-hyperkube-*.rpm \
+        /tmp/rpms/openshift-clients-[0-9]*.rpm \
+        /tmp/rpms/openshift-hyperkube-*.rpm \
     && rpm-ostree cleanup -m \
+    && ln -s /usr/sbin/ovs-vswitchd.dpdk /usr/sbin/ovs-vswitchd \
     && rm -rf /go /tmp/rpms /var/cache /var/lib/unbound \
     && systemctl preset-all \
     && ostree container commit

--- a/crio.repo
+++ b/crio.repo
@@ -1,9 +1,9 @@
 [cri-o_1.25]
-name=devel:kubic:libcontainers:stable:cri-o:1.25 (Fedora_37)
+name=devel:kubic:libcontainers:stable:cri-o:1.25 (Fedora_36)
 type=rpm-md
-baseurl=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.25/Fedora_37/
+baseurl=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.25/Fedora_36/
 gpgcheck=1
-gpgkey=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.25/Fedora_37/repodata/repomd.xml.key
+gpgkey=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.25/Fedora_36/repodata/repomd.xml.key
 enabled=1
 
 [cri-tools]
@@ -13,4 +13,3 @@ baseurl=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/
 gpgcheck=1
 gpgkey=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Fedora_37/repodata/repomd.xml.key
 enabled=1
-

--- a/crio.repo
+++ b/crio.repo
@@ -1,9 +1,9 @@
-[cri-o_1.25]
-name=devel:kubic:libcontainers:stable:cri-o:1.25 (Fedora_36)
+[cri-o_1.26]
+name=devel:kubic:libcontainers:stable:cri-o:1.26 (Fedora_37)
 type=rpm-md
-baseurl=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.25/Fedora_36/
+baseurl=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.26/Fedora_37/
 gpgcheck=1
-gpgkey=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.25/Fedora_36/repodata/repomd.xml.key
+gpgkey=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.26/Fedora_37/repodata/repomd.xml.key
 enabled=1
 
 [cri-tools]


### PR DESCRIPTION
This reverts commit e83e32a and reverts crio to use F36 package. This seems to fix failing local PV block tests