### PR TITLE
Dockerfile.ci: report real FCOS version

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 # Label okd-machine-os image with Fedora CoreOS version extracted from /etc/release
-FROM quay.io/fedora/fedora-coreos:stable
+FROM registry.ci.openshift.org/origin/4.12:machine-os-content
 COPY . /go/src/github.com/openshift/okd-machine-os
 WORKDIR /go/src/github.com/openshift/okd-machine-os
 RUN source /etc/os-release \


### PR DESCRIPTION
Dockerfile.ci should save actual FCOS version we're using in Dockerfile until FCOS is tracking stable again