### PR TITLE
[release-4.12] Revert "Dockerfile.ci: report real FCOS version"

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,5 +1,5 @@
 # Label okd-machine-os image with Fedora CoreOS version extracted from /etc/release
-FROM registry.ci.openshift.org/origin/4.12:machine-os-content
+FROM quay.io/fedora/fedora-coreos:stable
 COPY . /go/src/github.com/openshift/okd-machine-os
 WORKDIR /go/src/github.com/openshift/okd-machine-os
 RUN source /etc/os-release \


### PR DESCRIPTION
This reverts commit 65cd146cc6a5edc47e9e7a68ae180a23a7a60b79.
Fetch FCOS version from FCOS image again