### PR TITLE
[release-4.13] Dockerfile: use CRI-O 1.26

### DIFF
--- a/Dockerfile.rpms
+++ b/Dockerfile.rpms
@@ -2,7 +2,7 @@ FROM registry.ci.openshift.org/origin/4.13:artifacts as artifacts
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /rpms
-COPY okd-copr.repo /etc/yum.repos.d
+COPY crio.repo /etc/yum.repos.d
 RUN microdnf download cri-o cri-tools --archlist=$(arch) \
     && rm -rf /var/cache
 COPY --from=artifacts /srv/repo/*.rpm /rpms/

--- a/crio.repo
+++ b/crio.repo
@@ -1,0 +1,17 @@
+[cri-o_1.26]
+name=devel:kubic:libcontainers:stable:cri-o:1.26 (Fedora_37)
+type=rpm-md
+baseurl=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.26/Fedora_37/
+gpgcheck=1
+gpgkey=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.26/Fedora_37/repodata/repomd.xml.key
+enabled=1
+
+[cri-tools]
+name=Stable Releases of Upstream github.com/containers packages (Fedora_37)
+type=rpm-md
+baseurl=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Fedora_37/
+gpgcheck=1
+gpgkey=https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/Fedora_37/repodata/repomd.xml.key
+enabled=1
+
+

--- a/okd-copr.repo
+++ b/okd-copr.repo
@@ -1,8 +1,0 @@
-[okd-copr]
-name=Copr repo for OKD
-baseurl=https://download.copr.fedorainfracloud.org/results/@OKD/okd/fedora-37-$basearch/
-gpgcheck=1
-gpgkey=https://download.copr.fedorainfracloud.org/results/@OKD/okd/pubkey.gpg
-repo_gpgcheck=0
-enabled=1
-enabled_metadata=1


### PR DESCRIPTION
Make sure 4.13 nightlies are using stable CRI-O 1.26