### PR TITLE
[release-4.11] overlay: update selinux update script from 05rhcos

### DIFF
--- a/overlay.d/99okd/usr/libexec/rhcos-rebuild-selinux-policy
+++ b/overlay.d/99okd/usr/libexec/rhcos-rebuild-selinux-policy
@@ -1,1 +1,9 @@
-../../../../../../openshift-os/overlay.d/05rhcos/usr/libexec/rhcos-rebuild-selinux-policy
+#!/bin/bash
+# Executed by rhcos-selinux-policy-upgrade.service
+set -euo pipefail
+
+ls -al /{usr/,}etc/selinux/targeted/policy/policy.33
+if ! cmp --quiet /{usr/,}etc/selinux/targeted/policy/policy.33; then
+    echo "Recompiling policy due to local modifications as workaround for https://bugzilla.redhat.com/2057497"
+    semodule -B
+fi


### PR DESCRIPTION
remove version check from script so that it will run in fcos

Cherry-pick of https://github.com/openshift/okd-machine-os/pull/585 on release-4.11