### PR TITLE
Dockerfile: pass architecture arg to copy arch-specific binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,11 @@ FROM registry.ci.openshift.org/origin/4.12:artifacts as artifacts
 
 FROM quay.io/fedora/fedora-coreos:stable
 ARG FEDORA_COREOS_VERSION=412.37.1
+ARG ARCHITECTURE=x86_64
 
 WORKDIR /go/src/github.com/openshift/okd-machine-os
 COPY . .
-COPY --from=artifacts /srv/repo/ /tmp/rpms/
+COPY --from=artifacts /srv/repo/${ARCHITECTURE} /tmp/rpms/
 RUN cat /etc/os-release \
     && rpm-ostree --version \
     && ostree --version \


### PR DESCRIPTION
hello dear okd-team, please review pull-req

```
for release 4.12 additional (artifacts rpms) are placed at /srv/repo/${ARCHITECTURE}, i.e /srv/repo/x86_64 for intel x86_64 architecture. i guess it is true and for 4.13, not sure about 4.14
```