### PR TITLE
add SELinux policy for `ip` AVCs

### DIFF
--- a/overlay.d/99okd/usr/lib/okd/selinux-fixes.cil
+++ b/overlay.d/99okd/usr/lib/okd/selinux-fixes.cil
@@ -2,3 +2,10 @@
 (allow iscsid_t self (capability (dac_override)))
 ; iptables wrapper script fix
 (allow iptables_t container_runtime_tmpfs_t (chr_file (read write)))
+; https://github.com/okd-project/okd/discussions/1611
+(typeattributeset cil_gen_require ifconfig_t)
+(typeattributeset cil_gen_require container_runtime_tmpfs_t)
+(typeattributeset cil_gen_require container_runtime_t)
+(allow ifconfig_t container_runtime_t (fifo_file (append)))
+(allow ifconfig_t container_runtime_tmpfs_t (chr_file (read write)))
+(allow ifconfig_t self (capability (dac_override dac_read_search sys_ptrace)))


### PR DESCRIPTION
Some AVC like the following were generated.
```
AVC avc:  denied  { sys_ptrace } for  pid=59993 comm="ip" capability=19  scontext=system_u:system_r:ifconfig_t:s0 tcontext=system_u:system_r:ifconfig_t:s0 tclass=capability permissive=0
```

See okd-project/okd#1611