### PR TITLE
Add RPMs for ipsec extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN cat /etc/os-release \
     && cp -irvf manifests / \
     && cp -ivf *.repo /etc/yum.repos.d/ \
     && rpm-ostree install \
+        libreswan \
+        NetworkManager-libreswan \
         NetworkManager-ovs \
         open-vm-tools \
         qemu-guest-agent \


### PR DESCRIPTION
Adds the libreswan and NetworkManager-libreswan RPMs so IPSec tunnels can be configured on the nodes.

see https://github.com/openshift/os/pull/1308