### PR TITLE
manifests: remove intel_pstate=disable, enforce cgroupsv2

### DIFF
--- a/manifests/99-okd-master-disable-mitigations.yaml
+++ b/manifests/99-okd-master-disable-mitigations.yaml
@@ -15,4 +15,3 @@ spec:
       version: 3.2.0
   kernelArguments:
     - mitigations=off
-    - intel_pstate=disable

--- a/manifests/99-okd-master-disable-mitigations.yaml
+++ b/manifests/99-okd-master-disable-mitigations.yaml
@@ -15,3 +15,5 @@ spec:
       version: 3.2.0
   kernelArguments:
     - mitigations=off
+    - systemd.unified_cgroup_hierarchy=1
+    - systemd.legacy_systemd_cgroup_controller=0

--- a/manifests/99-okd-worker-disable-mitigations.yaml
+++ b/manifests/99-okd-worker-disable-mitigations.yaml
@@ -15,4 +15,3 @@ spec:
       version: 3.2.0
   kernelArguments:
     - mitigations=off
-    - intel_pstate=disable

--- a/manifests/99-okd-worker-disable-mitigations.yaml
+++ b/manifests/99-okd-worker-disable-mitigations.yaml
@@ -15,3 +15,5 @@ spec:
       version: 3.2.0
   kernelArguments:
     - mitigations=off
+    - systemd.unified_cgroup_hierarchy=1
+    - systemd.legacy_systemd_cgroup_controller=0


### PR DESCRIPTION
This was added to fix AWS bug, which has been long since resolved.

Ref: https://github.com/okd-project/okd/issues/1614