### PR TITLE
OCPBUGS-28548: Install ecr-credential-provider from artifacts instead of stub script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN cat /etc/os-release \
         cri-o \
         cri-tools \
         netcat \
+        /tmp/rpms/ecr-credential-provider-*.rpm \
         # TODO: temporary fix in the next two rows: see okd-project/okd-payload-pipeline#15
         /tmp/rpms/$([ -d /tmp/rpms/$(uname -m) ] && echo $(uname -m)/)openshift-clients-[0-9]*.rpm \
         /tmp/rpms/$([ -d /tmp/rpms/$(uname -m) ] && echo $(uname -m)/)openshift-hyperkube-*.rpm \

--- a/overlay.d/99okd/usr/libexec/kubelet-image-credential-provider-plugins/ecr-credential-provider
+++ b/overlay.d/99okd/usr/libexec/kubelet-image-credential-provider-plugins/ecr-credential-provider
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-exit 0


### PR DESCRIPTION
Depends on https://github.com/openshift/release/pull/48496