### PR TITLE
[release-4.15] Bump fedora-coreos to latest stable

### DIFF
--- a/overrides.yaml
+++ b/overrides.yaml
@@ -1,3 +1,11 @@
 override-remove:
  - moby-engine
  - zincati
+
+ex-override-replace:
+  - from:
+      repo: updates
+    packages:
+      # Pull the latest fix for https://github.com/okd-project/okd/issues/1481
+      - rpm-ostree
+      - rpm-ostree-libs


### PR DESCRIPTION
Includes rpm-ostree bump to fix missing proxy env vars issue