### PR TITLE
Removed symlink for ovs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,6 @@ RUN cat /etc/os-release \
         /tmp/rpms/$([ -d /tmp/rpms/$(uname -m) ] && echo $(uname -m)/)openshift-kube*.rpm \
     && rpm-ostree ex rebuild \
     && rpm-ostree cleanup -m \
-    # Symlink nc to netcat due to known issue in rpm-ostree - https://github.com/coreos/rpm-ostree/issues/1614
-    && ln -s /usr/bin/netcat /usr/bin/nc \
     && rm -rf /go /var/lib/unbound /tmp/rpms \
     && systemctl preset-all \
     && ostree container commit

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,6 @@ RUN cat /etc/os-release \
         /tmp/rpms/$([ -d /tmp/rpms/$(uname -m) ] && echo $(uname -m)/)openshift-kube*.rpm \
     && rpm-ostree ex rebuild \
     && rpm-ostree cleanup -m \
-    # Symlink ovs-vswitchd to dpdk version of OVS
-    && ln -s /usr/sbin/ovs-vswitchd.dpdk /usr/sbin/ovs-vswitchd \
     # Symlink nc to netcat due to known issue in rpm-ostree - https://github.com/coreos/rpm-ostree/issues/1614
     && ln -s /usr/bin/netcat /usr/bin/nc \
     && rm -rf /go /var/lib/unbound /tmp/rpms \


### PR DESCRIPTION
Our CI is telling us that this symlink/file already exists. This probably is not being used anymore, but in any case is good to take a look.

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/74222/rehearse-74222-pull-ci-openshift-okd-machine-os-master-images/2018337283035369472

```
ln: failed to create symbolic link '/usr/sbin/ovs-vswitchd': File exists
```